### PR TITLE
Add troubleshooting section to resolve ImageManager issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ https://github.com/armPelionEdge/cloud-installer/blob/master/djs-soft-relay/buil
 1. `[ERROR] Failed to create scratch path directory: mkdir /tmp/maestro/images: permission denied`
    `[ERROR] Failed to create scratch path directory: mkdir /var/maestro/images: permission denied`
 
-Maestro execution on local host creates directories at `/tmp/maestro/images` and `/var/maestro/images` path. Verify the ownership and write permissions for respective directories.
+Maestro execution on local host creates directories at `/tmp/maestro/images` and `/var/maestro/images` path. Verify that the user running `maestro` has the proper permissions to access the respective directories.
 

--- a/README.md
+++ b/README.md
@@ -134,3 +134,8 @@ cd .. && DEBUG=1 DEBUG2=1 ./build.sh && cd networking && sudo \
 
 The Docker build file, for `djs-soft-relay` shows build instruction also, using this exact above method.
 https://github.com/armPelionEdge/cloud-installer/blob/master/djs-soft-relay/build-wwcontainer.sh#L155
+
+#### TroubleShooting
+
+1. Maestro execution on local host creates directories at `/tmp/maestro/images` and `/var/maestro/images` path. Verify the ownership and write permissions for respective directories.
+

--- a/README.md
+++ b/README.md
@@ -137,5 +137,8 @@ https://github.com/armPelionEdge/cloud-installer/blob/master/djs-soft-relay/buil
 
 #### TroubleShooting
 
-1. Maestro execution on local host creates directories at `/tmp/maestro/images` and `/var/maestro/images` path. Verify the ownership and write permissions for respective directories.
+1. `[ERROR] Failed to create scratch path directory: mkdir /tmp/maestro/images: permission denied`
+   `[ERROR] Failed to create scratch path directory: mkdir /var/maestro/images: permission denied`
+
+Maestro execution on local host creates directories at `/tmp/maestro/images` and `/var/maestro/images` path. Verify the ownership and write permissions for respective directories.
 


### PR DESCRIPTION
***DEBUG_GO:doing InitImageManager()
[ERROR] Failed to create scratch path directory: mkdir /tmp/maestro/images: permission denied

[ERROR] Failed to create scratch path directory: mkdir /var/maestro/images: permission denied