### PR TITLE
Add debugging stats

### DIFF
--- a/src/maestro/main.go
+++ b/src/maestro/main.go
@@ -80,15 +80,15 @@ func main() {
 	configFlag := flag.String("config","./maestro.config","Config path")
 	dumpMetaVars := flag.Bool("dump_meta_vars",false,"Dump config file meta variables only")
 	versionFlag := flag.Bool("version",false,"Dump version information")
-	debugServerFlag := flag.Bool("debug_loopback",false,"Start a debug loopback on http://127.0.0.1:6060")
-
+	debugServerFlag := flag.Bool("debug_loopback",true,"Start a debug loopback on http://127.0.0.1:6060")
+	debugMemory := flag.Bool("debug_mem", true, "Debugging memory stats")
 	flag.Parse();
 
-	if *debugServerFlag {
-		// Debugging only - to profile
-		go func() {
-			fmt.Println(http.ListenAndServe("localhost:6060", nil))
-		}()
+	DebugPprof(*debugServerFlag)
+
+	if *debugMemory {
+        DumpMemStats();
+		go RuntimeMemStats(300)
 	}
 
 	if *versionFlag {


### PR DESCRIPTION
Move the existing debug stats code to debug file, so it is not accidentally part of production.
Added `RuntimeMemStats` API