### PR TITLE
DHCP handling changes to add request options and other changes

### DIFF
--- a/networking/api.go
+++ b/networking/api.go
@@ -257,7 +257,17 @@ func (this *DhcpLeaseInfo) IsValid() bool {
 }
 
 func (this *DhcpLeaseInfo) IsExpired() bool {
-	// TODO
+	var remainrenewal int64
+	now := time.Now().Unix()
+
+	remainrenewal = this.renewalTime - now
+	if remainrenewal < 30 {
+		remainrenewal = this.rebindTime - now
+	}
+	if remainrenewal >= 30 {
+		return true;
+	}
+
 	return false
 }
 
@@ -767,7 +777,8 @@ func RequestOrRenewDhcpLease(ifname string, leaseinfo *DhcpLeaseInfo, opts *dhcp
 	}
 	debugging.DEBUG_OUT("leaseinfo %+v\n", leaseinfo)
 
-	if leaseinfo == nil || !leaseinfo.IsValid() {
+	//If the lease is not valid or expired, get a new lease
+	if leaseinfo == nil || !leaseinfo.IsValid() || !leaseinfo.IsExpired() {
 		// totally new lease
 		success, acknowledgementpacket, err2 = dhcpclient.Request(opts)
 

--- a/networking/api.go
+++ b/networking/api.go
@@ -265,10 +265,10 @@ func (this *DhcpLeaseInfo) IsExpired() bool {
 		remainrenewal = this.rebindTime - now
 	}
 	if remainrenewal >= 30 {
-		return true;
+		return false
 	}
 
-	return false
+	return true
 }
 
 func (this *DhcpLeaseInfo) RemainOnLease() int64 {
@@ -778,7 +778,7 @@ func RequestOrRenewDhcpLease(ifname string, leaseinfo *DhcpLeaseInfo, opts *dhcp
 	debugging.DEBUG_OUT("leaseinfo %+v\n", leaseinfo)
 
 	//If the lease is not valid or expired, get a new lease
-	if leaseinfo == nil || !leaseinfo.IsValid() || !leaseinfo.IsExpired() {
+	if leaseinfo == nil || !leaseinfo.IsValid() || leaseinfo.IsExpired() {
 		// totally new lease
 		success, acknowledgementpacket, err2 = dhcpclient.Request(opts)
 


### PR DESCRIPTION
Following changes are made to DHCP handling in maestro:
1. Add MaxDHCPSize and VendorClassId options to all DHCP request packets
2. Do not attempt DHCP renewal when the lease is already expired.
3. Do not override read/write timeouts with Step Timeout, because step timeouts is for whole sequence where in multiple reads may be retried with in a Step timeout window.
4.  Reduce the read/write timeouts to 5 secs because we can retry faster on errors like EAGAIN without waiting too long. It doesn't affect the overall waiting time because default step timeout is left unchanged.