### PR TITLE
DHCP client changes to reorder options/parameters and to add right options to discover packet

### DIFF
--- a/networking/manager.go
+++ b/networking/manager.go
@@ -831,8 +831,8 @@ func (this *networkManagerInstance) doDhcp(ifname string, op maestroSpecs.NetInt
 	}
 
 	requestopts := new(dhcp4client.DhcpRequestOptions)
-	requestopts.AddRequestParam(dhcp4.OptionRouter)
 	requestopts.AddRequestParam(dhcp4.OptionSubnetMask)
+	requestopts.AddRequestParam(dhcp4.OptionRouter)
 	requestopts.AddRequestParam(dhcp4.OptionDomainNameServer)
 	requestopts.AddRequestParam(dhcp4.OptionHostName)
 	requestopts.AddRequestParam(dhcp4.OptionDomainName)

--- a/vendor/github.com/armPelionEdge/dhcp4client/client.go
+++ b/vendor/github.com/armPelionEdge/dhcp4client/client.go
@@ -378,13 +378,17 @@ func (c *Client) DiscoverPacket(opts *DhcpRequestOptions) dhcp4.Packet {
 	packet.SetBroadcast(c.broadcast)
 
 	packet.AddOption(dhcp4.OptionDHCPMessageType, []byte{byte(dhcp4.Discover)})
+	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, c.hardwareAddr))
+	packet.AddOption(dhcp4.OptionMaximumDHCPMessageSize, c.maxDHCPLenBytes)
 
 	if opts != nil {
 		if len(opts.RequestedParams) > 0 {
 			packet.AddOption(dhcp4.OptionParameterRequestList, opts.RequestedParams)
 		}
 	}
+	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
 	//packet.PadToMinSize()
+
 	return packet
 }
 
@@ -401,13 +405,16 @@ func (c *Client) DiscoverPacketUnicast(opts *DhcpRequestOptions) dhcp4.Packet {
 
 	packet.AddOption(dhcp4.OptionDHCPMessageType, []byte{byte(dhcp4.Discover)})
 	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, c.hardwareAddr))
+	packet.AddOption(dhcp4.OptionMaximumDHCPMessageSize, c.maxDHCPLenBytes)
 
 	if opts != nil {
 		if len(opts.RequestedParams) > 0 {
 			packet.AddOption(dhcp4.OptionParameterRequestList, opts.RequestedParams)
 		}
 	}
+	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
 	//packet.PadToMinSize()
+	
 	return packet
 }
 

--- a/vendor/github.com/armPelionEdge/dhcp4client/client.go
+++ b/vendor/github.com/armPelionEdge/dhcp4client/client.go
@@ -424,18 +424,18 @@ func (c *Client) RequestPacket(offerPacket *dhcp4.Packet) dhcp4.Packet {
 	//packet.SetSIAddr(offerPacket.SIAddr())
 
 	//	packet.SetBroadcast(c.broadcast)
-	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, offerPacket.CHAddr()))
 	packet.AddOption(dhcp4.OptionDHCPMessageType, []byte{byte(dhcp4.Request)})
+	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, offerPacket.CHAddr()))
 	packet.AddOption(dhcp4.OptionRequestedIPAddress, (offerPacket.YIAddr()).To4())
 	packet.AddOption(dhcp4.OptionServerIdentifier, offerOptions[dhcp4.OptionServerIdentifier])
 	packet.AddOption(dhcp4.OptionMaximumDHCPMessageSize, c.maxDHCPLenBytes)
-	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
-
+	
 	if c.opts != nil {
 		if len(c.opts.RequestedParams) > 0 {
 			packet.AddOption(dhcp4.OptionParameterRequestList, c.opts.RequestedParams)
 		}
 	}
+	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
 
 	return packet
 }
@@ -456,18 +456,18 @@ func (c *Client) RenewalRequestPacket(acknowledgement *dhcp4.Packet, opts *DhcpR
 	packet.SetSIAddr(net.IPv4(0, 0, 0, 0))
 
 	//	packet.SetBroadcast(c.broadcast)
-	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, acknowledgement.CHAddr()))
 	packet.AddOption(dhcp4.OptionDHCPMessageType, []byte{byte(dhcp4.Request)})
+	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, acknowledgement.CHAddr()))
 	packet.AddOption(dhcp4.OptionRequestedIPAddress, (acknowledgement.YIAddr()).To4())
 	packet.AddOption(dhcp4.OptionServerIdentifier, acknowledgementOptions[dhcp4.OptionServerIdentifier])
 	packet.AddOption(dhcp4.OptionMaximumDHCPMessageSize, c.maxDHCPLenBytes)
-	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
-
+	
 	if opts != nil {
 		if len(opts.RequestedParams) > 0 {
 			packet.AddOption(dhcp4.OptionParameterRequestList, opts.RequestedParams)
 		}
 	}
+	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
 
 	return packet
 }
@@ -488,17 +488,17 @@ func (c *Client) RenewalRequestPacketInitReboot(currentIP net.IP, opts *DhcpRequ
 	packet.SetSIAddr(net.IPv4(0, 0, 0, 0))
 
 	//	packet.SetBroadcast(c.broadcast)
-	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, c.hardwareAddr))
 	packet.AddOption(dhcp4.OptionDHCPMessageType, []byte{byte(dhcp4.Request)})
+	packet.AddOption(dhcp4.OptionClientIdentifier, dhcp4.MakeClientIdentifier(dhcp4.ClientIdentifierEthernet, c.hardwareAddr))
 	packet.AddOption(dhcp4.OptionRequestedIPAddress, currentIP.To4())
 	packet.AddOption(dhcp4.OptionMaximumDHCPMessageSize, c.maxDHCPLenBytes)
-	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
-
+	
 	if opts != nil {
 		if len(opts.RequestedParams) > 0 {
 			packet.AddOption(dhcp4.OptionParameterRequestList, opts.RequestedParams)
 		}
 	}
+	packet.AddOption(dhcp4.OptionVendorClassIdentifier, c.vendorClassId)
 
 	return packet
 }


### PR DESCRIPTION
This PR adds additional options to discover packet and also re-orders options/parameters in ascending order. The reordering is not mandated by protocol but this does make debugging easier when we capture network trace. I have tested the changes and discover packet changes appears to be fixing the Dhcp NAK issue as well.