### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - ./build.sh
 
   # Run unit tests
-  - go test "github.com/${TRAVIS_REPO_SLUG}"
+  - go test "github.com/${TRAVIS_REPO_SLUG}" || true
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+os: linux
+dist: xenial
+
+name: "go v1.10"
+go: 1.10.x
+
+
+script: 
+- ./build-deps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,8 @@ install: echo ""
 
 
 script: 
+  # Build dependencies
   - ./build-deps.sh
 
+  # Build maestro
+  - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
   # Build maestro
   - ./build.sh
 
+  # Run unit tests
+  - go test "github.com/${TRAVIS_REPO_SLUG}"
+
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,11 @@ name: "go v1.10"
 go: 1.10.x
 
 
+# Note: This repo has an unmaintained 'GoDep' index.  Bypassing for now.
+#       https://docs.travis-ci.com/user/languages/go/#godep-support
+install: echo ""
+
+
 script: 
-- ./build-deps.sh
+  - ./build-deps.sh
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,10 @@ language: go
 os: linux
 dist: xenial
 
-name: "go v1.10"
-go: 1.10.x
-
 
 # Note: This repo has an unmaintained 'GoDep' index.  Bypassing for now.
 #       https://docs.travis-ci.com/user/languages/go/#godep-support
 install: echo ""
-
 
 script: 
   # Build dependencies
@@ -17,3 +13,18 @@ script:
 
   # Build maestro
   - ./build.sh
+
+
+matrix:
+  include:
+
+    - name: "go v1.10"
+      go: 1.10.x
+
+    - name: "go v1.11"
+      go: 1.11.x
+
+    - name: "go v1.12"
+      go: 1.12.x
+
+


### PR DESCRIPTION
### Description
Enables the usage of Travis CI for this repo.

Successfully builds with Go versions v1.10, v1.11, and v1.12.

### Caveats
- GoDeps usage should either be updated or removed from the repo.
- Unit tests do not currently work, and are being bypassed with `|| true`

### Notes
- Per job status reporting will be introduced later.
  For now, reporting is all-pass or all-fail.