### PR TITLE
Travis CI: Properly build go in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,17 @@ env:
     - upstream="armPelionEdge/maestro"
 
 
-# Note: This repo has an unmaintained 'GoDep' index.  Bypassing for now.
-#       https://docs.travis-ci.com/user/languages/go/#godep-support
-install: echo ""
+# GoLang has an odd dependency management scheme.  Imports are hard-linked to
+# their parent repos.  Forked repos therefore must either modify _all_ of their
+# imports, or change their directory naming to match their parent.
+#
+# For reasons that I hope are obvious, we do the latter here.
+install: 
+  - |
+    mkdir -p "../../${upstream}"
+    mv * ".git" "../../${upstream}/"
+    cd "../../${upstream}"
+  
 
 script: 
   # Build dependencies
@@ -19,7 +27,7 @@ script:
   - ./build.sh
 
   # Run unit tests
-  - go test "github.com/${TRAVIS_REPO_SLUG}" || true
+  - go test "github.com/${upstream}" || true
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: go
 os: linux
 dist: xenial
 
+env:
+  global:
+    - upstream="armPelionEdge/maestro"
+
 
 # Note: This repo has an unmaintained 'GoDep' index.  Bypassing for now.
 #       https://docs.travis-ci.com/user/languages/go/#godep-support

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ env:
 # For reasons that I hope are obvious, we do the latter here.
 install: 
   - |
-    mkdir -p "../../${upstream}"
-    mv * ".git" "../../${upstream}/"
-    cd "../../${upstream}"
+    if [[ "${TRAVIS_REPO_SLUG}" != "${upstream}" ]]; then
+      mkdir -p "../../${upstream}"
+      mv * ".git" "../../${upstream}/"
+      cd "../../${upstream}"
+    fi
   
 
 script: 


### PR DESCRIPTION
### Description
It was found that the build scripts were not properly failing.
In getting those scripts to successfully fail, it was found that the current config did not properly build forks, because golang has some _really dumb_ opinions.

This config conditionally moves forks to the armMbedPelion/maestro directory before starting a build, because otherwise, golang fails to build...

### Notes
- A similar pattern can and will probably be used with other go projects.