### PR TITLE
Build script and readme fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: xenial
 env:
   global:
     - upstream="armPelionEdge/maestro"
+    - GOBIN="./bin"
 
 
 # GoLang has an odd dependency management scheme.  Imports are hard-linked to

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export GOBIN="$HOME/work/gostuff/bin"
 export PATH="$PATH:$GOROOT/bin:$GOBIN"
 ```
 
-then just run: `bash ./setup-go.sh` 
+then just run: `source ./setup-go.sh` 
 
 Run your build commands from this sub-shell.
 
@@ -116,7 +116,7 @@ Different subsystems have different test suites. Running these may require root 
 Example, from `$GOPATH/src/github.com/armPelionEdge/maestro`:
 
 ```
-DEBUG=1 DEBUG2=1 ./build.sh && cd networking && sudo \
+DEBUG=1 DEBUG2=1 ./build.sh && cd networking && sudo -E \
   LD_LIBRARY_PATH=../vendor/github.com/armPelionEdge/greasego/deps/lib go test -v -run DhcpRequest
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -36,9 +36,9 @@ GOTAGS=""
 if [[ -n "${DEBUG:-}" ]] || [[ -n "${DEBUG2:-}" ]]; then
   echo "DEBUG ON"
   GOTAGS="-tags debug"
-	make native.a-debug
+  make native.a-debug
 else
-	make native.a
+  make native.a
 fi
 
 popd
@@ -53,10 +53,19 @@ sed -i -e "s/BUILD_DATE/${DATE}/g" maestroutils/status.go
 # highlight errors: https://serverfault.com/questions/59262/bash-print-stderr-in-red-color
 # color()(set -o pipefail;"$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
 
+#Deveopers may have a GOBIN defined. If not define it to current dir.
+if [ -z "$GOBIN" ]
+then
+  GOBIN=.
+fi
+
 if [[ "${1:-}" != "preprocess_only" ]]; then
-	if [[ -n "${TIGHT:-}" ]]; then
-	    go build "${GOTAGS}" -ldflags="-s -w" "$@" github.com/armPelionEdge/maestro/maestro 
-	else
-	    go build "${GOTAGS}" "$@" github.com/armPelionEdge/maestro/maestro 
-	fi
+  mkdir -p $GOBIN
+  pushd $GOBIN
+  if [[ -n "${TIGHT:-}" ]]; then
+    go build ${GOTAGS} -ldflags="-s -w" "$@" github.com/armPelionEdge/maestro/maestro 
+  else
+    go build ${GOTAGS} "$@" github.com/armPelionEdge/maestro/maestro 
+  fi
+  popd
 fi

--- a/build.sh
+++ b/build.sh
@@ -53,10 +53,9 @@ sed -i -e "s/BUILD_DATE/${DATE}/g" maestroutils/status.go
 # highlight errors: https://serverfault.com/questions/59262/bash-print-stderr-in-red-color
 # color()(set -o pipefail;"$@" 2>&1>&3|sed $'s,.*,\e[31m&\e[m,'>&2)3>&1
 
-#Deveopers may have a GOBIN defined. If not define it to current dir.
-if [ -z "$GOBIN" ]
-then
-  GOBIN=.
+#Developers may have a GOBIN defined. If not define it to ./bin
+if [ -z "${GOBIN}" ]; then
+  GOBIN=./bin
 fi
 
 if [[ "${1:-}" != "preprocess_only" ]]; then


### PR DESCRIPTION
Fixes for build.sh failing with tags -debug not defined issue and minor updates to readme.