### PR TITLE
Fix for events unit tests failing in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,11 @@ script:
 
   # Run unit tests
   - cd "../../${upstream}"
-  - > 
-    (DEBUG=1 DEBUG2=1 ./build.sh;
-    cd sysstats;
-    LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v;
-    cd ..;
-    cd maestroConfig;
-    LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v;
-    cd ..;
-    )
-  
+  - DEBUG=1 DEBUG2=1 ./build.sh
+  - ( cd sysstats && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v )
+  - ( cd maestroConfig && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v )
+  - ( cd events && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v )
+
 matrix:
   include:
 


### PR DESCRIPTION
We were seeing events unit tests failing in CI and on debugging we found that to be test implementation issue as tests use too many parallel tests when not supported by the runtime. The current set of changes minimizes the required procs to be able to run CI.