### PR TITLE
Debug level 2 should not enabled always

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,10 +35,18 @@ pushd "${THIS_DIR}"
 GOTAGS=""
 if [[ -n "${DEBUG:-}" ]] || [[ -n "${DEBUG2:-}" ]]; then
   echo "DEBUG ON"
-  GOTAGS="-tags debug"
   make native.a-debug
 else
   make native.a
+fi
+
+if [[ -n "${DEBUG:-}" ]]; then
+  GOTAGS="-tags debug"
+fi
+
+if [[ -n "${DEBUG:-}" ]] && [[ -n "${DEBUG2:-}" ]]; then
+  echo "DEBUG2 ON"	
+  GOTAGS+=" -tags debug2"
 fi
 
 popd
@@ -61,6 +69,7 @@ fi
 if [[ "${1:-}" != "preprocess_only" ]]; then
   mkdir -p $GOBIN
   pushd $GOBIN
+  echo ${GOTAGS}
   if [[ -n "${TIGHT:-}" ]]; then
     go build ${GOTAGS} -ldflags="-s -w" "$@" github.com/armPelionEdge/maestro/maestro 
   else

--- a/build.sh
+++ b/build.sh
@@ -69,7 +69,6 @@ fi
 if [[ "${1:-}" != "preprocess_only" ]]; then
   mkdir -p $GOBIN
   pushd $GOBIN
-  echo ${GOTAGS}
   if [[ -n "${TIGHT:-}" ]]; then
     go build ${GOTAGS} -ldflags="-s -w" "$@" github.com/armPelionEdge/maestro/maestro 
   else

--- a/debugging/debug.go
+++ b/debugging/debug.go
@@ -45,8 +45,10 @@ func DEBUG_OUT(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
+// DEBUG_OUT2 is not enabled as default, uncomment the
+// function body if debug lebvel 2 prints are needed
 func DEBUG_OUT2(format string, args ...interface{}) {
-	fmt.Printf(format, args...)
+//	fmt.Printf(format, args...)
 }
 
 func DumpMemStats() {

--- a/debugging/debug.go
+++ b/debugging/debug.go
@@ -45,7 +45,6 @@ func DEBUG_OUT(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-//func DEBUG_OUT2(args ...interface{})  {}
 
 func DumpMemStats() {
 	var stats runtime.MemStats

--- a/debugging/debug.go
+++ b/debugging/debug.go
@@ -45,11 +45,7 @@ func DEBUG_OUT(format string, args ...interface{}) {
 	fmt.Printf(format, args...)
 }
 
-// DEBUG_OUT2 is not enabled as default, uncomment the
-// function body if debug lebvel 2 prints are needed
-func DEBUG_OUT2(format string, args ...interface{}) {
-//	fmt.Printf(format, args...)
-}
+//func DEBUG_OUT2(args ...interface{})  {}
 
 func DumpMemStats() {
 	var stats runtime.MemStats

--- a/debugging/debug2.go
+++ b/debugging/debug2.go
@@ -1,0 +1,26 @@
+// +build debug2
+
+package debugging
+
+// Copyright (c) 2018, Arm Limited and affiliates.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import (
+	"fmt"
+)
+
+func DEBUG_OUT2(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}

--- a/debugging/release.go
+++ b/debugging/release.go
@@ -1,11 +1,10 @@
-// +build !debug
+// +build !debug 
 
 package debugging
 
 const DebugEnabled = false
 
 func DEBUG_OUT(args ...interface{})  {}
-func DEBUG_OUT2(args ...interface{}) {}
 
 func DumpMemStats()                   {}
 func DebugPprof(debugServerFlag bool) {}

--- a/debugging/release2.go
+++ b/debugging/release2.go
@@ -1,0 +1,21 @@
+// +build !debug2
+
+package debugging
+
+// Copyright (c) 2018, Arm Limited and affiliates.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+func DEBUG_OUT2(format string, args ...interface{}) {}


### PR DESCRIPTION
We have 2 options here:
1. https://github.com/armPelionEdge/maestro/commit/750219796184dd0e26d4b22d82a44b4f0d2de7e3
Disable and enable from code when needed, but not as part of release (even debug release)

2. https://github.com/armPelionEdge/maestro/commit/300307a7938421561627de2cc81b07fcf9af21b0
Provide an independent option to disable the macro from command line during build.
Previously irrespective of `DEBUG2=1` set or not, if `DEBUG=1` is set the macro was enabled