### PR TITLE
Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ _testmain.go
 /.project
 *~
 .DS_Store
+
+.vagrant

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ vagrant plugin install vagrant-reload
 ### Why Vagrant?
 
 Maestro uses the `vagrant` for the following reasons:
-1. Reliability - Vagrant guarentees that every user that tries to build maestro gets the same environment and toolset.
+1. Reliability - Vagrant guarantees that every user that tries to build maestro gets the same environment and toolset.
 2. Network control - Unlike docker, vagrant allows us to specify network interfaces. Specifically, we setup a control and test network, which is explained in the `vagrant` folder README
 3. System testing - Once again a limitation to docker, vagrant allows us to start and stop the maestro daemon and configure the system for complete system testing. Additionally, we can bring in other daemons into the system over time for additional testing (ex. devicedb, devicejs)
 
@@ -57,12 +57,18 @@ For more information as to how vagrant sets up the maestro environment, please r
 
 ## Building
 
-Start up the virtual machine:
+Start up the virtual machine. The very first time `vagrant up` is run, the VM will go through a provisioning phase.
 
 ```bash
 git clone git@github.com:armPelionEdge/maestro.git
 cd maestro
 vagrant up
+```
+
+Then build maestro and its dependencies. You can run this whenever you desire as long as the VM is online
+
+```bash
+vagrant ssh -c "build_maestro"
 ```
 
 ## Running
@@ -88,7 +94,7 @@ go test -v -run DhcpRequest # Run DhcpRequest test
 ### System Tests
 
 On the host machine, run the following commands:
-Note: Make sure you had built using `vagrant up` before running tests.
+Note: Make sure you had built using `vagrant up` and `vagrant ssh -c "build_maestro"` before running tests.
 
 ```bash
 cd tests # Go to SysTests folder

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,5 +8,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "~/.ssh/known_hosts", destination: "~/.ssh/known_hosts"
   config.vm.provision :shell, path: "vagrant/provision.sh"
   config.vm.provision :reload
-  config.vm.provision :shell, path: "vagrant/build.sh", run: 'always', privileged: false
+  config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
+  config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
+  config.ssh.extra_args = "-t"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,4 +9,5 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, path: "vagrant/provision.sh"
   config.vm.provision :reload
   config.vm.provision :shell, path: "vagrant/build.sh", run: 'always', privileged: false
+  config.ssh.extra_args = "-t"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,10 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
-  config.vm.network "public_network", bridge: "enp0s31f6"
+  config.vm.network "private_network", type: "dhcp"
   config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "~/.ssh/id_rsa"
   config.vm.provision "file", source: "~/.ssh/known_hosts", destination: "~/.ssh/known_hosts"
   config.vm.provision :shell, path: "vagrant/provision.sh"
   config.vm.provision :reload
   config.vm.provision :shell, path: "vagrant/build.sh", run: 'always', privileged: false
-  config.ssh.extra_args = "-t"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+  config.vm.network "public_network", bridge: "enp0s31f6"
+  config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "~/.ssh/id_rsa"
+  config.vm.provision "file", source: "~/.ssh/known_hosts", destination: "~/.ssh/known_hosts"
+  config.vm.provision :shell, path: "vagrant/provision.sh"
+  config.vm.provision :reload
+  config.vm.provision :shell, path: "vagrant/build.sh", run: 'always', privileged: false
+end

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 package-lock.json
 node_modules/
+reports/

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "maestro-tests",
+  "version": "1.0.0",
+  "description": "System testing suite for maestro",
+  "main": "test.js",
+  "scripts": {
+    "test": "./node_modules/mocha/bin/mocha"
+  },
+  "author": "michael.ray@arm.com",
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "devDependencies": {
+    "mocha": "^6.2.2",
+    "shelljs": "^0.8.3"
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,13 +4,14 @@
   "description": "System testing suite for maestro",
   "main": "test.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "./node_modules/mocha/bin/mocha --reporter mochawesome --reporter-options reportDir=reports,reportFilename=tests.html"
   },
   "author": "michael.ray@arm.com",
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
     "mocha": "^6.2.2",
+    "mochawesome": "^4.1.0",
     "shelljs": "^0.8.3"
   }
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,191 @@
+const assert = require('assert');
+const shell = require('shelljs');
+const fs = require('fs');
+
+let maestro_src = '/home/vagrant/work/gostuff/src/github.com/armPelionEdge/maestro';
+let maestro_bin = '/home/vagrant/work/gostuff/bin/maestro';
+let maestro_config_name = 'maestro.config';
+
+let command_maestro = 'vagrant ssh -c "sudo maestro"';
+let command_vagrant_upload = 'vagrant upload {{in_file}} {{out_file}}';
+let command_kill = 'vagrant ssh -c "sudo pkill maestro"';
+let command_dhcp_check = 'vagrant ssh -c "ps -aef | grep dhcp"';
+let command_ip_addr = 'vagrant ssh -c "ip addr show eth1"';
+let command_ip_flush = 'vagrant ssh -c "sudo ip addr flush dev eth1"';
+
+let template_network_config = `
+network:
+    interfaces:
+        - if_name: eth1
+          existing: replace
+          dhcpv4: true
+          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+config_end: true
+`;
+
+let template_network_config_no_dhcp = `
+network:
+    interfaces:
+        - if_name: eth1
+          existing: replace
+          dhcpv4: false
+          ipv4_addr: 10.123.123.123
+          ipv4_mask: 24
+config_end: true
+`;
+
+// Allow 30 seconds for the test to run, and provide 5 seconds for test cleanup
+const timeout = 30000;
+const timeout_cleanup = 5000;
+
+/**
+ * Check an ip addr command to verify a valid IP address exists
+ * @param {String} ip - IP address that should be available (or portion of an IP)
+ * @param {callback} cb - Callback to run when done
+ **/
+function check_ip_addr(ip, cb)
+{
+    shell.exec(command_ip_addr, { silent: true}, function(code, stdout, stderr) {
+        let arr = stdout.split('\n');
+        for (var i in arr) {
+            let line = arr[i].trim();
+            let words = line.split(' ');
+            if (words.length >= 4 && words[0] === 'inet' && words[1].includes(ip)) {
+                this.cb(true);
+                return;
+            }
+        }
+        this.cb(false);
+    }.bind({ctx: this, cb: cb}));
+}
+
+/**
+ * Save a config file to disk
+ * @param {String} file_name - Name of the file on disk to save to
+ * @param {String} config - Config content to write
+ * @param {callback} cb - Callback to run when done
+ **/
+function save_config(file_name, config, cb)
+{
+    fs.writeFile(file_name, config, function(err) {
+        assert.ifError(err);
+        if (!err)
+            this.cb(this.file_name);
+    }.bind({ctx: this, cb: cb, file_name: file_name}));
+}
+
+/**
+ * Upload a file to the vagrant VM
+ * @param {String} file_name - Name of the file on disk to upload
+ * @param {callback} cb - Callback when the upload has finished
+ **/
+function upload_to_vagrant(file_name, cb)
+{
+    // Insert file names into the command
+    let command = command_vagrant_upload.replace('{{in_file}}', file_name);
+    command = command.replace('{{out_file}}', maestro_src + '/' + file_name);
+    // Upload config file to the vagrant VM
+    shell.exec(command, { silent: true}, function(code, stdout, stderr) {
+        assert.equal(code, 0);
+        assert.equal(stderr, '');
+        this.cb();
+    }.bind({ctx: this, cb: cb}));
+}
+
+/**
+ * Start maestro on the vagrant VM
+ * @param {callback} done - Callback to the mocha test done callback
+ * @param {callback} condition_cb - Callback to the function to test if the condition has been met
+ **/
+function start_maestro(done, condition_cb)
+{
+    // Start maestro up in the background, and listen for 
+    var child = shell.exec(command_maestro, { async: true, silent: true });
+    child.stdout.on('data', function(data) {
+        if (this.cb(data)) {
+            shell.exec(command_kill, { silent: true});
+            this.done();
+        }
+    }.bind({ctx: this, done: done, cb: condition_cb}));
+}
+
+/**
+ * Workflow that every test should run. Use this within an in block
+ * @param {String} config - Configuration to use for maestro
+ * @param {callback} done - Callback to the mocha test done callback
+ * @param {callback} checker_cb - Callback to run when a new output is received from maestro
+ **/
+function maestro_workflow(config, done, checker_cb)
+{
+    save_config(maestro_config_name, config, function(file_name) {
+        upload_to_vagrant(file_name, function() {
+            start_maestro(this.done, this.checker_cb);
+        }.bind(this));
+    }.bind({ctx: this, done: done, checker_cb: checker_cb}));
+}
+
+
+/**
+ * Networking tests
+ **/
+describe('Networking', function() {
+
+    /**
+     * DHCP tests
+     **/
+    describe('DCHP', function() {
+
+        afterEach(function() {
+            this.timeout(timeout_cleanup);
+            shell.exec(command_kill, { silent: true});
+        });
+
+        it('should enable DCHP for eth1 when specified in the configuration file provided to maestro', function(done) {
+            this.timeout(timeout);
+            shell.exec(command_ip_flush, { silent: true});
+            maestro_workflow(template_network_config, done, function(data) {
+                return data.includes('DHCP') && data.includes('Lease acquired');
+            });
+        });
+
+        it('should now have a DHCP enabled IP address', function(done) {
+            this.timeout(timeout);
+            check_ip_addr('10.', function(contains_ip) {
+                assert(contains_ip, 'Interface eth1 not set with an IP address prefixed with 10.xxx.yyy.zzz');
+                this.done();
+            }.bind({ctx: this, done: done}));
+        });
+
+        it('should disable DCHP for eth1 when specified in the configuration file provided to maestro', function(done) {
+            this.timeout(timeout);
+            shell.exec(command_ip_flush, { silent: true});
+            maestro_workflow(template_network_config_no_dhcp, done, function(data) {
+                return data.includes('Static address set on eth1 of 10.123.123.123');
+            });
+        });
+
+        it('should now have a static enabled IP address', function(done) {
+            this.timeout(timeout);
+            check_ip_addr('10.123.123.123', function(contains_ip) {
+                assert(contains_ip, 'Interface eth1 not set with IP address 10.123.123.123');
+                this.done();
+            }.bind({ctx: this, done: done}));
+        });
+
+        it('should disable DCHP when no networking configuration is specified in the configuration file provided to maestro', function(done) {
+            this.timeout(timeout);
+            shell.exec(command_ip_flush, { silent: true});
+            maestro_workflow('', done, function(data) {
+                return data.includes('Static address set on');
+            });
+        });
+
+        it('should now have a static enabled IP address', function(done) {
+            this.timeout(timeout);
+            check_ip_addr('10.123.123.123', function(contains_ip) {
+                assert(contains_ip, 'Interface eth1 not set with IP address 10.123.123.123');
+                this.done();
+            }.bind({ctx: this, done: done}));
+        });
+    });
+});

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,12 +6,13 @@ let maestro_src = '/home/vagrant/work/gostuff/src/github.com/armPelionEdge/maest
 let maestro_bin = '/home/vagrant/work/gostuff/bin/maestro';
 let maestro_config_name = 'maestro.config';
 
-let command_maestro = 'vagrant ssh -c "sudo maestro"';
-let command_vagrant_upload = 'vagrant upload {{in_file}} {{out_file}}';
-let command_kill = 'vagrant ssh -c "sudo pkill maestro"';
-let command_dhcp_check = 'vagrant ssh -c "ps -aef | grep dhcp"';
-let command_ip_addr = 'vagrant ssh -c "ip addr show eth1"';
-let command_ip_flush = 'vagrant ssh -c "sudo ip addr flush dev eth1"';
+let vm_name = 'default';
+let command_maestro = 'vagrant ssh ' + vm_name + ' -c "sudo maestro"';
+let command_vagrant_upload = 'vagrant upload {{in_file}} {{out_file}} ' + vm_name;
+let command_kill = 'vagrant ssh ' + vm_name + ' -c "sudo pkill maestro"';
+let command_dhcp_check = 'vagrant ' + vm_name + ' ssh -c "ps -aef | grep dhcp"';
+let command_ip_addr = 'vagrant ssh ' + vm_name + ' -c "ip addr show eth1"';
+let command_ip_flush = 'vagrant ssh ' + vm_name + ' -c "sudo ip addr flush dev eth1"';
 
 let template_network_config = `
 network:
@@ -150,7 +151,7 @@ describe('Networking', function() {
 
         it('should now have a DHCP enabled IP address', function(done) {
             this.timeout(timeout);
-            check_ip_addr('10.', function(contains_ip) {
+            check_ip_addr('172.28.128.', function(contains_ip) {
                 assert(contains_ip, 'Interface eth1 not set with an IP address prefixed with 10.xxx.yyy.zzz');
                 this.done();
             }.bind({ctx: this, done: done}));

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,67 @@
+# Vagrant and maestro
+
+This readme is dedicated to explaining the details of how maestro works with vagrant
+
+## Background
+
+There are 2 scripts that vagrant utilizes:
+* provision.sh
+* build.sh
+
+### Provision
+
+See: `provision.sh`
+
+Provisioning occurs at vagrant virtual machine creation. This runs the very first time a user creates a vagrant VM and will never run again unless the original VM is deleted from disk or a user specifically restarts the provisioning phase of the VM.
+
+The command to manually run provisioning on a VM is as follows:
+
+```bash
+vagrant reload --provision
+```
+
+#### Script details
+
+The provision script does the following:
+* Installs required apt packages
+* Download and installs Go into `/opt/go`
+* Creates a `envvars.sh` script which contains the Go environment variables
+    * This script lives in `/etc/profile.d/envvars.sh` and can be sourced within a shell to give the user the Go environment variables and paths
+* Creates a read/write maestro folder in `/var/maestro`
+* Renames the network interfaces to the old Ubuntu network interface naming convention (`eth0`, `eth1`, etc)
+* Creates 2 networks within the VM
+    * `eth0` - This is the control network, and is managed by vagrant (NAT). SSH and test commands are sent over this interface
+    * `eth1` - This is the test network. Maestro is allowed to configure this network however it wants, and vagrant/Ubuntu will not interact with this interface. This allows maestro to enable/disable DCHP on the network interface without locking out SSH functionality
+
+### Build
+
+See: `build.sh`
+
+Building occurs every time the user brings up the vagrant VM. This can occur with the following command:
+
+```bash
+vagrant build
+```
+
+or
+
+```bash
+vagrant reload
+```
+
+#### Script details
+
+The build script does the following:
+* Sources the Go environment variables
+* Builds maestro dependencies
+* Builds maestro
+* Creates a default `maestro.config` that is placed in the maestro home directory
+* Builds maestro-shell
+
+## Additional information
+
+### Jenkins default network interface
+
+You may notice that in the `Vagrantfile` in the maestro home directory, the interface `enp0s31f6` is specified.
+
+This interface is the default interface for our Jenkins machine and can be changed for your host machine. If the interface is not changed, and is not available on your machine, vagrant will ask you when starting up for a replacement network interface to bridge

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Load go environment variables
+. /etc/profile.d/envvars.sh
+
+# Import GO project maestro
+go get github.com/armPelionEdge/maestro || true
+
+# Build greaselib for grease_echo utility
+# cd $GOPATH/src/github.com/armPelionEdge/greasego
+# sed -i -e 's/make libgrease.a-server/make all/g' build-deps.sh
+
+# Go to newly created maestro directory
+cd $MAESTRO_SRC
+
+# Build maestro dependencies
+./build-deps.sh
+
+# Build maestro
+DEBUG=1 DEBUG2=1 ./build.sh
+
+# Create maestro dummy config if config does not exist
+[ -f maestro.config ] || \
+echo 'network:
+    interfaces:
+        - if_name: eth1
+          exists: replace
+          dhcpv4: true
+          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+config_end: true
+' >> maestro.config

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -29,3 +29,7 @@ echo 'network:
           hw_addr: "{{ARCH_ETHERNET_MAC}}"
 config_end: true
 ' >> maestro.config
+
+# Import GO project maestro-shell
+go get github.com/armPelionEdge/maestro-shell || true
+go install github.com/armPelionEdge/maestro-shell

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Install prerequisite packages
+apt-get update
+apt-get install -y build-essential python wget git nodejs npm m4
+
+# Download GO
+wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz
+tar xvzf go1.13.5.linux-amd64.tar.gz
+rm go1.13.5.linux-amd64.tar.gz
+rm -rf /opt/go
+mv go /opt/go
+
+# Set GO environment variables
+echo "export GIT_TERMINAL_PROMPT=1
+export GOROOT=/opt/go
+export GOPATH=/home/vagrant/work/gostuff
+export GOBIN=/home/vagrant/work/gostuff/bin
+export PATH=$PATH:/opt/go/bin:/home/vagrant/work/gostuff/bin
+export MAESTRO_SRC=/home/vagrant/work/gostuff/src/github.com/armPelionEdge/maestro
+export LD_LIBRARY_PATH=/home/vagrant/work/gostuff/src/github.com/armPelionEdge/maestro/vendor/github.com/armPelionEdge/greasego/deps/lib
+" > /etc/profile.d/envvars.sh
+. /etc/profile.d/envvars.sh
+
+# Create directories for read/write of vagrant user
+mkdir /var/maestro
+chmod 777 /var/maestro
+
+# Create a script to go to the maestro source and run maestro so maestro has access to its' configuration files
+# Allows a user to run 'sudo maestro' and have everything work out
+echo "#!/bin/bash
+. /etc/profile.d/envvars.sh
+cd $MAESTRO_SRC
+$GOBIN/maestro
+" > /usr/sbin/maestro
+chmod +x /usr/sbin/maestro
+
+# Set the network interface to eth0 instead of Ubuntu 16.04 default enp0s3
+rm /etc/udev/rules.d/70-persistent-net.rules
+sed -i -e 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
+update-grub
+
+# Add a secondary network interface for test traffic
+echo "auto lo
+iface lo inet loopback
+auto eth0
+iface eth0 inet dhcp
+" > /etc/network/interfaces.d/50-cloud-init.cfg

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -28,10 +28,10 @@ chmod 777 /var/maestro
 
 # Create a script to go to the maestro source and run maestro so maestro has access to its' configuration files
 # Allows a user to run 'sudo maestro' and have everything work out
-echo "#!/bin/bash
+echo "#!/bin/bash -ue
 . /etc/profile.d/envvars.sh
 cd $MAESTRO_SRC
-$GOBIN/maestro
+exec $GOBIN/maestro
 " > /usr/sbin/maestro
 chmod +x /usr/sbin/maestro
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -12,14 +12,15 @@ rm -rf /opt/go
 mv go /opt/go
 
 # Set GO environment variables
-echo "export GIT_TERMINAL_PROMPT=1
+cat <<'EOF' >/etc/profile.d/envvars.sh
+export GIT_TERMINAL_PROMPT=1
 export GOROOT=/opt/go
 export GOPATH=/home/vagrant/work/gostuff
-export GOBIN=/home/vagrant/work/gostuff/bin
-export PATH=$PATH:/opt/go/bin:/home/vagrant/work/gostuff/bin
-export MAESTRO_SRC=/home/vagrant/work/gostuff/src/github.com/armPelionEdge/maestro
-export LD_LIBRARY_PATH=/home/vagrant/work/gostuff/src/github.com/armPelionEdge/maestro/vendor/github.com/armPelionEdge/greasego/deps/lib
-" > /etc/profile.d/envvars.sh
+export GOBIN=$GOPATH/bin
+export PATH=$PATH:$GOROOT/bin:$GOBIN
+export MAESTRO_SRC=$GOPATH/src/github.com/armPelionEdge/maestro
+export LD_LIBRARY_PATH=$MAESTRO_SRC/vendor/github.com/armPelionEdge/greasego/deps/lib
+EOF
 . /etc/profile.d/envvars.sh
 
 # Create directories for read/write of vagrant user

--- a/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.cc
+++ b/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.cc
@@ -545,10 +545,16 @@ int GreaseLogger::logSync(const logMeta &f, const char *s, int len) { // does th
 		return GREASE_OK;
 }
 void GreaseLogger::flushAll(bool nocallbacks) { // flushes buffers. Synchronous
+	static bool suppressTargetMsg = false;
 	if(LOGGER->defaultTarget) {
 		LOGGER->defaultTarget->flushAll();
-	} else
-		ERROR_OUT("No default target!");
+		suppressTargetMsg = false;
+	} else {
+		if(!suppressTargetMsg) {
+			ERROR_OUT("No default target!");
+			suppressTargetMsg = true;
+		}
+	}
 
 	logTarget **t; // shut down other targets.
 	GreaseLogger::TargetTable::HashIterator iter(LOGGER->targets);


### PR DESCRIPTION
Added vagrant to simplify the build and run process for maestro. Due to the fact that maestro is a system management feature, we could not use docker.

Changed the default way to build maestro in the README to vagrant as setting up the exact environment and network interfaces was complicated and often error-prone.

See the README on how to use vagrant to build and run maestro.