### PR TITLE
Build/Run DeviceDB in Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ npm test # Run mocha test suite
 
 In order to test additional maestro functionality, the vagrant VM has the ability to startup and run devicedb, another Arm Pelion Edge gateway feature.
 
-To start devicedb within your vagrant VM, run the following command from your host machine:
+Before going further, please make sure you have built maestro using the instructions above. If you built when in a SSH shell, please restart your shell.
+
+To start devicedb, run the following command from your host machine:
 
 ```bash
-vagrant ssh -c "devicedb"
+vagrant ssh -c "devicedb_server"
 ```

--- a/README.md
+++ b/README.md
@@ -105,3 +105,15 @@ cd tests # Go to SysTests folder
 npm i # Only run once to download dependencies
 npm test # Run mocha test suite
 ```
+
+## Additional Features/Information
+
+### DeviceDB
+
+In order to test additional maestro functionality, the vagrant VM has the ability to startup and run devicedb, another Arm Pelion Edge gateway feature.
+
+To start devicedb within your vagrant VM, run the following command from your host machine:
+
+```bash
+vagrant ssh -c "devicedb"
+```

--- a/README.md
+++ b/README.md
@@ -110,12 +110,18 @@ npm test # Run mocha test suite
 
 ### DeviceDB
 
-In order to test additional maestro functionality, the vagrant VM has the ability to startup and run devicedb, another Arm Pelion Edge gateway feature.
+In order to test additional maestro functionality, the vagrant VM automatically installs and runs DeviceDB Edge and DeviceDB Cloud in the background. See [DeviceDB](https://github.com/armPelionEdge/devicedb) for more information.
 
-Before going further, please make sure you have built maestro using the instructions above. If you built when in a SSH shell, please restart your shell.
-
-To start devicedb, run the following command from your host machine:
-
+To view logs from DeviceDB Edge, run:
 ```bash
-vagrant ssh -c "devicedb_server"
+vagrant ssh
+sudo journalctl -u devicedb_edge
 ```
+
+To view logs from DeviceDB Cloud, run:
+```bash
+vagrant ssh
+docker ps
+docker logs <container-id>"
+```
+Where `<container-id>` is the ID of the DeviceDB Server docker container that was shown in `docker ps`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :reload
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
   config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
+  config.vm.provision "file", source: "vagrant/docker-compose.yaml", destination: "/tmp/docker-compose.yaml"
   config.vm.provision "file", source: "patches/0001-Fake-devicedb-running-on-local-machine.patch", destination: "/tmp/0001-Fake-devicedb-running-on-local-machine.patch"
   config.ssh.extra_args = "-t"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,10 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "private_network", type: "dhcp"
+  config.vm.network "private_network", ip: "172.28.128.1"
   config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "~/.ssh/id_rsa"
   config.vm.provision "file", source: "~/.ssh/known_hosts", destination: "~/.ssh/known_hosts"
+  config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/id_rsa.pub"
   config.vm.provision :shell, path: "vagrant/provision.sh"
   config.vm.provision :reload
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
   config.vm.network "private_network", type: "dhcp"
-  config.vm.network "private_network", ip: "172.28.128.1"
+  config.vm.network "private_network", ip: "172.28.128.1", auto_config: false
   config.vm.provision "file", source: "~/.ssh/id_rsa", destination: "~/.ssh/id_rsa"
   config.vm.provision "file", source: "~/.ssh/known_hosts", destination: "~/.ssh/known_hosts"
   config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/id_rsa.pub"
@@ -12,5 +12,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :reload
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
   config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
+  config.vm.provision "file", source: "patches/0001-Fake-devicedb-running-on-local-machine.patch", destination: "/tmp/0001-Fake-devicedb-running-on-local-machine.patch"
   config.ssh.extra_args = "-t"
 end

--- a/patches/0001-Fake-devicedb-running-on-local-machine.patch
+++ b/patches/0001-Fake-devicedb-running-on-local-machine.patch
@@ -1,0 +1,36 @@
+From 6c328ee424992739bd14a82a75094ec431eab46a Mon Sep 17 00:00:00 2001
+From: Michael Ray <michael.ray@arm.com>
+Date: Thu, 9 Jan 2020 22:16:48 +0000
+Subject: [PATCH] Fake devicedb running on local machine
+
+Current way of running devicedb is within docker and therefore
+devicedb is not running as a local process
+---
+ networking/manager.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/networking/manager.go b/networking/manager.go
+index b05815a..7196753 100644
+--- a/networking/manager.go
++++ b/networking/manager.go
+@@ -50,7 +50,6 @@ import (
+ 	"github.com/armPelionEdge/maestro/networking/arp"
+ 	"github.com/armPelionEdge/maestro/storage"
+ 	"github.com/armPelionEdge/maestro/tasks"
+-	"github.com/armPelionEdge/maestro/processes"
+ 	"github.com/armPelionEdge/maestro/maestroConfig"
+ 	"github.com/armPelionEdge/maestroSpecs"
+ 	"github.com/armPelionEdge/maestroSpecs/netevents"
+@@ -874,7 +873,8 @@ func (this *networkManagerInstance) initDeviceDBConfig() {
+ 		log.MaestroInfof("initDeviceDBConfig: Waiting for devicedb process/job\n")
+ 		for totalWaitTime < MAX_DEVICEDB_WAIT_TIME_IN_SECS {
+ 			//First wait for devicedb to start
+-			devicedbrunning, pid = processes.IsJobActive(DEVICEDB_JOB_NAME)
++			devicedbrunning = true
++			pid = 8573
+ 			log.MaestroWarnf("initDeviceDBConfig: devicedbrunning: %v, pid: %d\n", devicedbrunning, pid)
+ 			if(devicedbrunning) {
+ 				//Service is started, but wait for some seconds for the port to be up and running
+-- 
+2.7.4
+

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules/
 reports/
+maestro.config

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -2,6 +2,7 @@
 
 # Load go environment variables
 . /etc/profile.d/envvars.sh
+sudo usermod -aG docker $USER
 
 # Import GO project maestro
 go get github.com/armPelionEdge/maestro || true
@@ -33,3 +34,10 @@ config_end: true
 # Import GO project maestro-shell
 go get github.com/armPelionEdge/maestro-shell || true
 go install github.com/armPelionEdge/maestro-shell
+
+# Import project devicedb
+cd $MAESTRO_SRC/..
+git clone git@github.com:armPelionEdge/devicedb.git
+
+cd devicedb
+mkdir edgeconfig

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -2,14 +2,16 @@
 
 # Load go environment variables
 . /etc/profile.d/envvars.sh
-sudo usermod -aG docker $USER
+
+# Setup default email and name for github. Needed to apply patches
+git config --global user.email "fake@email.com"
+git config --global user.name "Vagrant User"
+
+# Set go get to use SSH instead of https due to the private devicedb repo
+git config --global url.git@github.com:.insteadOf https://github.com/
 
 # Import GO project maestro
 go get github.com/armPelionEdge/maestro || true
-
-# Build greaselib for grease_echo utility
-# cd $GOPATH/src/github.com/armPelionEdge/greasego
-# sed -i -e 's/make libgrease.a-server/make all/g' build-deps.sh
 
 # Go to newly created maestro directory
 cd $MAESTRO_SRC
@@ -18,34 +20,59 @@ cd $MAESTRO_SRC
 ./build-deps.sh
 
 # Apply maestro patch
-git config --global user.email "fake@email.com"
-git config --global user.name "Vagrant User"
 git am /tmp/0001-Fake-devicedb-running-on-local-machine.patch
 
 # Build maestro
 DEBUG=1 DEBUG2=1 ./build.sh
 
-# Create maestro dummy config if config does not exist
-[ -f maestro.config ] || \
-echo 'network:
-    interfaces:
-        - if_name: eth1
-          exists: replace
-          dhcpv4: true
-          hw_addr: "{{ARCH_ETHERNET_MAC}}"
-config_end: true
-' >> maestro.config
-
 # Import GO project maestro-shell
 go get github.com/armPelionEdge/maestro-shell || true
 go install github.com/armPelionEdge/maestro-shell
 
-# Set go get to use SSH instead of https due to the private devicedb repo
-git config --global url.git@github.com:.insteadOf https://github.com/
-
 # Import project devicedb
-cd $MAESTRO_SRC/..
-go get github.com/armPelionEdge/devicedb
+go get github.com/armPelionEdge/devicedb || true
 
-# Create directory for devicedb certificates
-mkdir -p devicedb/edgeconfig
+# Generate devicedb certs and identity file
+cd $DEVICEDB_SRC/hack
+mkdir -p certs
+./generate-certs-and-identity.sh certs
+
+# Startup devicedb cloud in background
+cp /tmp/docker-compose.yaml $DEVICEDB_SRC/docker-compose.yaml
+docker-compose up -d
+
+# Add device and site information to the cloud
+./compose-cloud-add-device.sh certs
+
+# Restart devicedb edge
+sudo systemctl restart devicedb_edge
+
+cd $MAESTRO_SRC
+
+# Read Device ID from certs folder
+DEVICE_ID=$(cat $DEVICEDB_SRC/hack/certs/device_id)
+
+# Set a host for the device-id that devicedb uses
+if grep -Fxq "unconfigured-devicedb-host" /etc/hosts
+then
+    sudo sed -i "s/unconfigured-devicedb-host/$DEVICE_ID/g" /etc/hosts || true
+else
+    echo "127.0.0.1       $DEVICE_ID" | sudo tee -a /etc/hosts
+fi
+
+# Create maestro dummy config if config does not exist
+[ -f maestro.config ] || \
+echo "network:
+    interfaces:
+        - if_name: eth1
+          exists: replace
+          dhcpv4: true
+          hw_addr: \"{{ARCH_ETHERNET_MAC}}\"
+devicedb_conn_config:
+    devicedb_uri: \"https://$DEVICE_ID:9090\"
+    devicedb_prefix: \"vagrant\"
+    devicedb_bucket: \"lww\"
+    relay_id: \"$DEVICE_ID\"
+    ca_chain: \"$DEVICEDB_SRC/hack/certs/myCA.pem\"
+config_end: true
+" >> maestro.config

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -17,6 +17,11 @@ cd $MAESTRO_SRC
 # Build maestro dependencies
 ./build-deps.sh
 
+# Apply maestro patch
+git config --global user.email "fake@email.com"
+git config --global user.name "Vagrant User"
+git am /tmp/0001-Fake-devicedb-running-on-local-machine.patch
+
 # Build maestro
 DEBUG=1 DEBUG2=1 ./build.sh
 
@@ -35,9 +40,12 @@ config_end: true
 go get github.com/armPelionEdge/maestro-shell || true
 go install github.com/armPelionEdge/maestro-shell
 
+# Set go get to use SSH instead of https due to the private devicedb repo
+git config --global url.git@github.com:.insteadOf https://github.com/
+
 # Import project devicedb
 cd $MAESTRO_SRC/..
-git clone git@github.com:armPelionEdge/devicedb.git
+go get github.com/armPelionEdge/devicedb
 
-cd devicedb
-mkdir edgeconfig
+# Create directory for devicedb certificates
+mkdir -p devicedb/edgeconfig

--- a/vagrant/docker-compose.yaml
+++ b/vagrant/docker-compose.yaml
@@ -1,0 +1,27 @@
+# Setup for devicedb cloud node
+version: '3'
+services:
+  devicedb-cloud:
+    build: .
+    restart: always
+    command:
+    - devicedb
+    - cluster
+    - start
+    - -store
+    - /var/lib/devicedb/data
+    - -snapshot_store
+    - /var/lib/devicedb/snapshots
+    - -replication_factor
+    - "1"
+    - -host
+    - "0.0.0.0"
+    ports:
+    - "8080:8080"
+    volumes:
+    - devicedb-identity:/etc/devicedb
+    - devicedb-cloud-data:/var/lib/devicedb
+    - ${EDGE_CLIENT_RESOURCES}:/etc/devicedb/shared
+volumes:
+  devicedb-identity:
+  devicedb-cloud-data:

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -2,7 +2,13 @@
 
 # Install prerequisite packages
 apt-get update
-apt-get install -y build-essential python wget git nodejs npm m4
+apt-get install -y build-essential python wget git nodejs npm m4 docker.io docker-compose
+systemctl start docker
+systemctl enable docker
+
+# Install docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
 
 # Download GO
 wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz
@@ -20,6 +26,8 @@ export GOBIN=$GOPATH/bin
 export PATH=$PATH:$GOROOT/bin:$GOBIN
 export MAESTRO_SRC=$GOPATH/src/github.com/armPelionEdge/maestro
 export LD_LIBRARY_PATH=$MAESTRO_SRC/vendor/github.com/armPelionEdge/greasego/deps/lib
+export DEVICEDB_SRC=$GOPATH/src/github.com/armPelionEdge/devicedb
+export EDGE_CLIENT_RESOURCES=$DEVICEDB_SRC/edgeconfig
 EOF
 . /etc/profile.d/envvars.sh
 
@@ -35,6 +43,14 @@ cd $MAESTRO_SRC
 exec $GOBIN/maestro
 " > /usr/sbin/maestro
 chmod +x /usr/sbin/maestro
+
+# Create a script to go to the devicedb source and run devicedb
+echo "#!/bin/bash -ue
+. /etc/profile.d/envvars.sh
+cd $DEVICEDB_SRC
+docker-compose up
+" > /usr/sbin/devicedb
+chmod +x /usr/sbin/devicedb
 
 # Set the network interface to eth0 instead of Ubuntu 16.04 default enp0s3
 rm /etc/udev/rules.d/70-persistent-net.rules

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -49,8 +49,8 @@ echo "#!/bin/bash -ue
 . /etc/profile.d/envvars.sh
 cd $DEVICEDB_SRC
 docker-compose up
-" > /usr/sbin/devicedb
-chmod +x /usr/sbin/devicedb
+" > /usr/sbin/devicedb_server
+chmod +x /usr/sbin/devicedb_server
 
 # Set the network interface to eth0 instead of Ubuntu 16.04 default enp0s3
 rm /etc/udev/rules.d/70-persistent-net.rules


### PR DESCRIPTION
In order to test new functionality in maestro, configurations must be changed dynamically during runtime.

There are 2 ways of doing this: maestro-shell and devicedb.

This PR builds deviceDB inside of vagrant and runs both DeviceDB Edge (systemd) and DeviceDB Cloud (docker) in the background. The default maestro.config now includes the information to connect to DeviceDB Edge.

Information on how to use it and why things were done the way they were can be found in the readme in this PR as well as the PR into deviceDB:
https://github.com/armPelionEdge/devicedb/pull/9