### PR TITLE
Add cloud and file logging to vagrant maestro config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/id_rsa.pub"
   config.vm.provision :shell, path: "vagrant/provision.sh"
   config.vm.provision :reload
+  config.vm.provision "file", source: "vagrant/maestro.config", destination: "/tmp/maestro.config"
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
   config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
   config.vm.provision "file", source: "vagrant/docker-compose.yaml", destination: "/tmp/docker-compose.yaml"

--- a/vagrant/maestro.config
+++ b/vagrant/maestro.config
@@ -1,0 +1,64 @@
+network:
+    interfaces:
+        - if_name: eth1
+          exists: replace
+          dhcpv4: false
+          ipv4_addr: 10.0.103.103
+          ipv4_mask: 24
+          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+        - if_name: eth2
+          exists: replace
+          dhcpv4: false
+          ipv4_addr: 10.0.102.102
+          ipv4_mask: 24
+          hw_addr: "{{ARCH_ETHERNET_MAC}}"
+devicedb_conn_config:
+    devicedb_uri: "https://{{DEVICE_ID}}:9090"
+    devicedb_prefix: "vagrant"
+    devicedb_bucket: "lww"
+    relay_id: "{{DEVICE_ID}}"
+    ca_chain: "{{DEVICEDB_SRC}}/hack/certs/myCA.pem"
+sys_stats: # system stats intervals
+  vm_stats:
+    every: "15s"
+    name: vm
+  disk_stats:
+    every: "30s"
+    name: disk
+symphony:
+    sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
+    sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
+    client_cert: {{SYMPHONY_CLIENT_CRT}}
+    client_key: {{SYMPHONY_CLIENT_KEY}}
+    host: "{{SYMPHONY_HOST}}"
+targets:
+    - file: "/var/lib/maestro.log"
+      rotate:
+        max_files: 4
+        max_file_size: 10000000  # 10MB max file size
+        max_total_size: 42000000
+        rotate_on_start: true
+      delim: "\n"
+      format_time: "[%ld:%d] "
+      format_level: "<%s> "
+      format_tag: "{%s} "
+      format_origin: "(%s) "
+      filters:
+      - levels: warn
+        format_pre: "\u001B[33m"    # yellow
+        format_post: "\u001B[39m"
+      - levels: error
+        format_pre: "\u001B[31m"    # red
+        format_post: "\u001B[39m"
+    - name: "toCloud"  # this is a special target for sending to the cloud. It must send as a JSON
+      format_time: "\"timestamp\":%ld%03d, "
+      format_level: "\"level\":\"%s\", "
+      format_tag: "\"tag\":\"%s\", "
+      format_origin: "\"origin\":\"%s\", "
+      format_pre_msg: "\"text\":\""
+      format_post: "\"},"
+      flag_json_escape_strings: true
+      filters:
+      - levels: all
+        format_pre: "{"     # you will wrap this output with { "log": [ OUTPUT ] }
+config_end: true

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Install prerequisite packages
+add-apt-repository ppa:rmescandon/yq
 apt-get update
-apt-get install -y build-essential python wget git nodejs npm m4 docker.io docker-compose uuid
+apt-get install -y build-essential python wget git nodejs npm m4 docker.io docker-compose uuid yq
 systemctl start docker
 systemctl enable docker
 
@@ -37,6 +38,7 @@ export EDGE_DATA_DIRECTORY=/var/lib/devicedb/data
 export EDGE_SNAP_DIRECTORY=/var/lib/devicedb/snapshots
 export EDGE_LISTEN_PORT=9090
 export EDGE_LOG_LEVEL=info
+export MAESTRO_CERTS=/var/lib/maestro/certs
 export EDGE_CLIENT_CERT=$EDGE_CLIENT_RESOURCES/client.crt
 export EDGE_CLIENT_KEY=$EDGE_CLIENT_RESOURCES/client.key
 export EDGE_CLIENT_CA=$EDGE_CLIENT_RESOURCES/myCA.pem
@@ -113,6 +115,8 @@ mkdir -p $EDGE_SNAP_DIRECTORY
 chmod 777 $EDGE_SNAP_DIRECTORY
 mkdir -p $EDGE_DATA_DIRECTORY
 chmod 777 $EDGE_DATA_DIRECTORY
+mkdir -p $MAESTRO_CERTS
+chmod 777 $MAESTRO_CERTS
 
 # Create a script to go to the maestro source and run maestro so maestro has access to its' configuration files
 # Allows a user to run 'sudo maestro' and have everything work out


### PR DESCRIPTION
Install yq tool, yaml editing command line utility
Clone edge-utils into the vagrant vm to get identity scripts
Run identity scripts to create certs
Use yq tool to insert scripts into maestro.config

Maestro now logs to file and cloud