### PR TITLE
Moving log structs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - DEBUG=1 DEBUG2=1 ./build.sh
   - ( cd sysstats && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v )
   - ( cd maestroConfig && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v )
-  - ( cd vendor/github.com/armPelionEdge/maestroSpecs && go test -v )
+  - ( cd vendor/github.com/armPelionEdge/maestroSpecs && LD_LIBRARY_PATH=../greasego/deps/lib/ go test -v )
   - ( cd networking && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v -run NetworkConfigInDDB )
   - ( cd networking && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v -run NetworkConfigSimpleUpdateInDDB )
   - ( cd networking && LD_LIBRARY_PATH=../../maestro/vendor/github.com/armPelionEdge/greasego/deps/lib/ go test -v -run ConfigCommitUpdateInDDB )

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -53,15 +53,15 @@
 		},
 		{
 			"ImportPath": "github.com/armPelionEdge/maestroSpecs",
-			"Rev": "f7044471ed9ebab46e90f7c59112ef3630543d9f"
+			"Rev": "a4b807ad5365d3287cb646935c86fea42ca8225b"
 		},
 		{
 			"ImportPath": "github.com/armPelionEdge/maestroSpecs/netevents",
-			"Rev": "f7044471ed9ebab46e90f7c59112ef3630543d9f"
+			"Rev": "a4b807ad5365d3287cb646935c86fea42ca8225b"
 		},
 		{
 			"ImportPath": "github.com/armPelionEdge/maestroSpecs/templates",
-			"Rev": "f7044471ed9ebab46e90f7c59112ef3630543d9f"
+			"Rev": "a4b807ad5365d3287cb646935c86fea42ca8225b"
 		},
 		{
 			"ImportPath": "github.com/armPelionEdge/mustache",

--- a/maestroConfig/config.go
+++ b/maestroConfig/config.go
@@ -64,7 +64,7 @@ type YAMLMaestroConfig struct {
 	Symphony             *wwrmi.ClientConfig                     `yaml:"symphony"`
 	SysStats             *sysstats.StatsConfig                   `yaml:"sys_stats"`
 	Tags                 []string                                `yaml:"tags"`
-	Targets              []LogTarget                             `yaml:"targets"`
+	Targets              []maestroSpecs.LogTarget                `yaml:"targets"`
 	ClientId             string                                  `yaml:"clientId"`
 	ConfigDBPath         string                                  `yaml:"configDBPath"` // where Maestro should look for it's database
 	Stats                maestroSpecs.StatsConfigPayload         `yaml:"stats"`
@@ -137,52 +137,6 @@ type StaticFileOp struct {
 	TemplateFile   string `yaml:"template_file"`
 	TemplateString string `yaml:"template"`
 	OutputFile     string `yaml:"output_file"`
-}
-
-type LogRotate struct {
-	MaxFiles      uint32 `yaml:"max_files,omitempty" greaseAssign:"Max_files"`
-	RotateOnStart bool   `yaml:"rotate_on_start,omitempty" greaseAssign:"Rotate_on_start"`
-	MaxFileSize   uint32 `yaml:"max_file_size,omitempty" greaseAssign:"Max_file_size"`
-	MaxTotalSize  uint64 `yaml:"max_total_size,omitempty" greaseAssign:"Max_total_size"`
-}
-
-type LogTarget struct {
-	File                     string                           `yaml:"file,omitempty" greaseAssign:"File"`
-	TTY                      string                           `yaml:"tty,omitempty" greaseAssign:"TTY"`
-	Format                   LogFormat                        `yaml:"format,omitempty"`
-	Filters                  []LogFilter                      `yaml:"filters"`
-	Rotate                   LogRotate                        `yaml:"rotate,omitempty" greaseAssign:"FileOpts"`
-	ExampleFileOpts          greasego.GreaseLibTargetFileOpts `greaseType:"FileOpts"`
-	Delim                    string                           `yaml:"delim,omitempty" greaseAssign:"Delim"`
-	FormatPre                string                           `yaml:"format_pre,omitempty" greaseAssign:"Format_pre"`
-	FormatTime               string                           `yaml:"format_time,omitempty" greaseAssign:"Format_time"`
-	FormatLevel              string                           `yaml:"format_level,omitempty" greaseAssign:"Format_level"`
-	FormatTag                string                           `yaml:"format_tag,omitempty" greaseAssign:"Format_tag"`
-	FormatOrigin             string                           `yaml:"format_origin,omitempty" greaseAssign:"Format_origin"`
-	FormatPost               string                           `yaml:"format_post,omitempty" greaseAssign:"Format_post"`
-	FormatPreMsg             string                           `yaml:"format_pre_msg,omitempty" greaseAssign:"Format_pre_msg"`
-	Name                     string                           `yaml:"name,omitempty"`
-	Flag_json_escape_strings bool                             `yaml:"flag_json_escape_strings"`
-}
-
-type LogFormat struct {
-	Time   string `yaml:"time,omitempty"`
-	Level  string `yaml:"level,omitempty"`
-	Tag    string `yaml:"tag,omitempty"`
-	Origin string `yaml:"origin,omitempty"`
-}
-
-type LogFilter struct {
-	Target string `yaml:"target,omitempty"` // target: "default",
-	Levels string `yaml:"levels,omitempty"`
-	Tag    string `yaml:"tag,omitempty"`
-
-	Pre           string `yaml:"format_pre,omitempty" greaseAssign:"Format_pre"`
-	Post          string `yaml:"format_post,omitempty" greaseAssign:"Format_post"`
-	PostFmtPreMsg string `yaml:"fmt_post_pre_msg,omitempty"  greaseAssign:"Format_post_pre_msg"`
-	//	format_pre *string`
-	//	format_post *string
-	//	format_post_pre_msg *string
 }
 
 var re_this_dir *regexp.Regexp // {{thisdir}}

--- a/vendor/github.com/armPelionEdge/maestroSpecs/logger.go
+++ b/vendor/github.com/armPelionEdge/maestroSpecs/logger.go
@@ -1,5 +1,9 @@
 package maestroSpecs
 
+import (
+	"github.com/armPelionEdge/greasego"
+)
+
 // Copyright (c) 2018, Arm Limited and affiliates.
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -15,19 +19,64 @@ package maestroSpecs
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// A Logger interface is passed to some Maestro plugins, allowing the 
+// A Logger interface is passed to some Maestro plugins, allowing the
 // plugin to Log to Maestro's internal logs, as part of the Maestro
 // process.
 type Logger interface {
-    Info(a ...interface{})
-    Infof(format string, a ...interface{})
-    Success(a ...interface{})
-    Successf(format string, a ...interface{})
-    Warn(a ...interface{})
-    Warnf(format string, a ...interface{})
-    Error(a ...interface{})
-    Errorf(format string, a ...interface{})
-    Debug(a ...interface{})
-    Debugf(format string, a ...interface{})
+	Info(a ...interface{})
+	Infof(format string, a ...interface{})
+	Success(a ...interface{})
+	Successf(format string, a ...interface{})
+	Warn(a ...interface{})
+	Warnf(format string, a ...interface{})
+	Error(a ...interface{})
+	Errorf(format string, a ...interface{})
+	Debug(a ...interface{})
+	Debugf(format string, a ...interface{})
 }
 
+type LogRotate struct {
+	MaxFiles      uint32 `yaml:"max_files,omitempty" greaseAssign:"Max_files"`
+	RotateOnStart bool   `yaml:"rotate_on_start,omitempty" greaseAssign:"Rotate_on_start"`
+	MaxFileSize   uint32 `yaml:"max_file_size,omitempty" greaseAssign:"Max_file_size"`
+	MaxTotalSize  uint64 `yaml:"max_total_size,omitempty" greaseAssign:"Max_total_size"`
+}
+
+type LogTarget struct {
+	File                     string                           `yaml:"file,omitempty" greaseAssign:"File"`
+	TTY                      string                           `yaml:"tty,omitempty" greaseAssign:"TTY"`
+	Format                   LogFormat                        `yaml:"format,omitempty"`
+	Filters                  []LogFilter                      `yaml:"filters"`
+	Rotate                   LogRotate                        `yaml:"rotate,omitempty" greaseAssign:"FileOpts"`
+	ExampleFileOpts          greasego.GreaseLibTargetFileOpts `greaseType:"FileOpts"`
+	Delim                    string                           `yaml:"delim,omitempty" greaseAssign:"Delim"`
+	FormatPre                string                           `yaml:"format_pre,omitempty" greaseAssign:"Format_pre"`
+	FormatTime               string                           `yaml:"format_time,omitempty" greaseAssign:"Format_time"`
+	FormatLevel              string                           `yaml:"format_level,omitempty" greaseAssign:"Format_level"`
+	FormatTag                string                           `yaml:"format_tag,omitempty" greaseAssign:"Format_tag"`
+	FormatOrigin             string                           `yaml:"format_origin,omitempty" greaseAssign:"Format_origin"`
+	FormatPost               string                           `yaml:"format_post,omitempty" greaseAssign:"Format_post"`
+	FormatPreMsg             string                           `yaml:"format_pre_msg,omitempty" greaseAssign:"Format_pre_msg"`
+	Name                     string                           `yaml:"name,omitempty"`
+	Flag_json_escape_strings bool                             `yaml:"flag_json_escape_strings"`
+}
+
+type LogFormat struct {
+	Time   string `yaml:"time,omitempty"`
+	Level  string `yaml:"level,omitempty"`
+	Tag    string `yaml:"tag,omitempty"`
+	Origin string `yaml:"origin,omitempty"`
+}
+
+type LogFilter struct {
+	Target string `yaml:"target,omitempty"` // target: "default",
+	Levels string `yaml:"levels,omitempty"`
+	Tag    string `yaml:"tag,omitempty"`
+
+	Pre           string `yaml:"format_pre,omitempty" greaseAssign:"Format_pre"`
+	Post          string `yaml:"format_post,omitempty" greaseAssign:"Format_post"`
+	PostFmtPreMsg string `yaml:"fmt_post_pre_msg,omitempty"  greaseAssign:"Format_post_pre_msg"`
+	//	format_pre *string`
+	//	format_post *string
+	//	format_post_pre_msg *string
+}


### PR DESCRIPTION
Moving the logging structs to maestroSpecs so more than one project can have access to them.

the other side of this is maestroSpec:

armPelionEdge/maestroSpecs@9dacc7c

which has already been merged.