### PR TITLE
Bug fix: Do not start the network manager if no network params set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+system('git rev-parse HEAD > vagrant/githash.txt')
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
@@ -13,6 +14,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :reload
   config.vm.provision "file", source: "vagrant/maestro.config", destination: "/tmp/maestro.config"
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
+  config.vm.provision "file", source: "vagrant/githash.txt", destination: "/tmp/githash.txt"
   config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
   config.vm.provision "file", source: "vagrant/docker-compose.yaml", destination: "/tmp/docker-compose.yaml"
   config.vm.provision "file", source: "patches/0001-PATCH-Fake-devicedb-running-on-local-machine.patch", destination: "/tmp/0001-PATCH-Fake-devicedb-running-on-local-machine.patch"

--- a/maestro/main.go
+++ b/maestro/main.go
@@ -454,10 +454,6 @@ func main() {
 	/*             Network startup               */
 	/*********************************************/
 	neterr := networking.InitNetworkManager(config.Network, config.DDBConnConfig)
-	if neterr != nil {
-		Log.MaestroErrorf("Error starting networking subsystem! %s\n", neterr.Error())
-		log.Errorf("Error starting networking subsystem! %s\n", neterr.Error())
-	}
 
 	bringUpIfs := func() {
 		// wait a few seconds to start interface bring up. we want the logging to be working, and
@@ -553,7 +549,13 @@ func main() {
 
 	}
 
-	go bringUpIfs()
+	if neterr != nil {
+		Log.MaestroErrorf("Error starting networking subsystem! %s\n", neterr.Error())
+		log.Errorf("Error starting networking subsystem! %s\n", neterr.Error())
+	} else {
+		go bringUpIfs()
+	}
+
 
 	/*********************************************/
 	/*               Jobs startup                */

--- a/maestro/main.go
+++ b/maestro/main.go
@@ -453,7 +453,6 @@ func main() {
 	/*********************************************/
 	/*             Network startup               */
 	/*********************************************/
-	neterr := networking.InitNetworkManager(config.Network, config.DDBConnConfig)
 
 	bringUpIfs := func() {
 		// wait a few seconds to start interface bring up. we want the logging to be working, and
@@ -549,6 +548,7 @@ func main() {
 
 	}
 
+	neterr := networking.InitNetworkManager(config.Network, config.DDBConnConfig)
 	if neterr != nil {
 		Log.MaestroErrorf("Error starting networking subsystem! %s\n", neterr.Error())
 		log.Errorf("Error starting networking subsystem! %s\n", neterr.Error())

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -2152,7 +2152,7 @@ func InitNetworkManager(networkconfig *maestroSpecs.NetworkConfigPayload, ddbcon
 		log.MaestroInfof("NetworkManager: Submit config read from config file\n")
 		inst.submitConfig(inst.networkConfig)
 	} else {
-		log.MaestroErrorf("NetworkManager: No network configuration set, unable to cofigure network\n")
+		return errors.New("NetworkManager: No network configuration set, unable to cofigure network")
 	}
 
 	return

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -52,9 +52,8 @@ module.exports = class Commands {
             maestro_identity_get_cert: 'vagrant ssh -c "cat ' + maestro_certs + '/device_cert.pem"',
             maestro_identity_get_key: 'vagrant ssh -c "cat ' + maestro_certs + '/device_private_key.pem"',
 
-            maestro_shell_get_iface: 'vagrant ssh -c "sudo curl -XGET --unix-socket /tmp/maestroapi.sock http:/net/interfaces"',
-            maestro_shell_put_iface: 'vagrant ssh -c "sudo curl -XPUT --unix-socket /tmp/maestroapi.sock http:/net/interfaces -d \'{{payload}}\'"',
-            maestro_shell_put_log: 'vagrant ssh -c "echo \'N/A\'"',
+            maestro_shell_get: 'vagrant ssh -c "sudo curl -XGET --unix-socket /tmp/maestroapi.sock http:{{url}}"',
+            maestro_shell_put: 'vagrant ssh -c "sudo curl -XPUT --unix-socket /tmp/maestroapi.sock http:{{url}} -d \'{{payload}}\'"',
 
             devicedb_commit: 'vagrant ssh -c \'devicedb cluster put -site {{site_id}} -bucket lww -key vagrant.{{relay_id}}.MAESTRO_NETWORK_CONFIG_COMMIT_FLAG -value \'\\\'\'{"name":"vagrant.{{relay_id}}.MAESTRO_NETWORK_CONFIG_COMMIT_FLAG","body":"{\\\"config_commit\\\":true}"}\'\\\'',
             devicedb_put: 'echo \'devicedb cluster put -site {{site_id}} -bucket lww -key vagrant.{{relay_id}}.MAESTRO_NETWORK_CONFIG_ID -value \'\\\'\'{{payload}}\'\\\' | vagrant ssh'

--- a/tests/test.js
+++ b/tests/test.js
@@ -274,6 +274,21 @@ describe('Maestro Config', function() {
     });
 });
 
+function maestro_api_set_log_target(ctx)
+{
+    let view = [];
+    let json_view = JSON.stringify(view);
+    json_view = json_view.replace(/"/g, '\\\"');
+
+    let command = Commands.list.maestro_shell_put;
+    command = command.replace('{{url}}', '/log/target');
+    command = command.replace('{{payload}}', json_view);
+
+    maestro_commands.run_shell(command, function(result) {
+        console.log(result);
+    }.bind({ctx: ctx}));
+}
+
 function maestro_api_set_ip_address(ctx, interface, ip_address)
 {
     let view = [{
@@ -286,7 +301,8 @@ function maestro_api_set_ip_address(ctx, interface, ip_address)
     let json_view = JSON.stringify(view);
     json_view = json_view.replace(/"/g, '\\\"');
 
-    let command = Commands.list.maestro_shell_put_iface;
+    let command = Commands.list.maestro_shell_put;
+    command = command.replace('{{url}}', '/net/interfaces');
     command = command.replace('{{payload}}', json_view);
 
     maestro_commands.run_shell(command, function(result) {
@@ -330,7 +346,9 @@ describe('Maestro API', function() {
         it('should retrieve the active maestro config', function(done) {
             this.timeout(timeout);
             this.done = done;
-            maestro_commands.run_shell(Commands.list.maestro_shell_get_iface, function(active_iface) {
+            let command = Commands.list.maestro_shell_get;
+            command = command.replace('{{url}}', '/net/interfaces');
+            maestro_commands.run_shell(command, function(active_iface) {
                 let active_config = JSON.parse(active_iface);
 
                 let iface_arr = this.view.network.interfaces;

--- a/tests/test.js
+++ b/tests/test.js
@@ -412,40 +412,41 @@ describe('DeviceDB', function() {
         this.timeout(timeout * 2);
         this.done = done;
         // Flush the IP table to get a clean slate
-        maestro_commands.run_shell(Commands.list.ip_flush, null);
+        maestro_commands.run_shell(Commands.list.ip_flush, function() {
 
-        // Get the site ID to connect to devicedb properly
-        maestro_commands.get_site_id(function(site_id) {
-            // Check for invalid site IDs
-            assert.notEqual(site_id, '', 'Site ID not obtained!');
-            this.site_id = site_id;
-
-            // Get the relay ID to connect to devicedb properly
-            maestro_commands.get_device_id(function(device_id) {
+            // Get the site ID to connect to devicedb properly
+            maestro_commands.get_site_id(function(site_id) {
                 // Check for invalid site IDs
-                assert.notEqual(device_id, '', 'Device/Relay ID not obtained!');
-                this.device_id = device_id;
+                assert.notEqual(site_id, '', 'Site ID not obtained!');
+                this.site_id = site_id;
 
-                // Create the config
-                let view = {
-                    network: {
-                        interfaces: [
-                            {if_name: 'eth1', existing: 'replace', dhcpv4: false, ipv4_addr: '10.77.77.77', ip_mask: 24},
-                            {if_name: 'eth2', existing: 'replace', dhcpv4: false, ipv4_addr: '10.66.66.66', ip_mask: 24}
-                        ]
-                    },
-                    devicedb_conn_config: {
-                        devicedb_uri: 'https://' + device_id + ':9090',
-                        devicedb_prefix: 'vagrant',
-                        devicedb_bucket: 'lww',
-                        relay_id: device_id,
-                        ca_chain: Commands.devicedb_src + '/hack/certs/myCA.pem'
-                    },
-                    config_end: true
-                };
+                // Get the relay ID to connect to devicedb properly
+                maestro_commands.get_device_id(function(device_id) {
+                    // Check for invalid site IDs
+                    assert.notEqual(device_id, '', 'Device/Relay ID not obtained!');
+                    this.device_id = device_id;
 
-                maestro_commands.maestro_workflow(YAML.stringify(view), null, null);
-                setTimeout(this.done, timeout);
+                    // Create the config
+                    let view = {
+                        network: {
+                            interfaces: [
+                                {if_name: 'eth1', existing: 'replace', dhcpv4: false, ipv4_addr: '10.77.77.77', ip_mask: 24},
+                                {if_name: 'eth2', existing: 'replace', dhcpv4: false, ipv4_addr: '10.66.66.66', ip_mask: 24}
+                            ]
+                        },
+                        devicedb_conn_config: {
+                            devicedb_uri: 'https://' + device_id + ':9090',
+                            devicedb_prefix: 'vagrant',
+                            devicedb_bucket: 'lww',
+                            relay_id: device_id,
+                            ca_chain: Commands.devicedb_src + '/hack/certs/myCA.pem'
+                        },
+                        config_end: true
+                    };
+
+                    maestro_commands.maestro_workflow(YAML.stringify(view), null, null);
+                    setTimeout(this.done, timeout);
+                }.bind(this));
             }.bind(this));
         }.bind(this));
     });

--- a/tests/test.js
+++ b/tests/test.js
@@ -17,6 +17,40 @@ describe('Maestro Config', function() {
     });
 
     /**
+     * Generic tests
+     **/
+    describe('Generic', function() {
+
+        it('should continue running when only "config_end: true" is specified in the configuration file provided to maestro', function(done) {
+            this.timeout(timeout);
+            maestro_commands.maestro_workflow('config_end: true',
+
+                // Function to run when done with the workflow
+                done,
+
+                // Function to run whenever a new stream of data comes accross STDOUT
+                function(data) {
+                    return data.includes('[ERROR] Error starting networking subsystem!');
+                }
+            );
+        });
+
+        it('should continue running when nothing is specified in the configuration file provided to maestro', function(done) {
+            this.timeout(timeout);
+            maestro_commands.maestro_workflow('',
+
+                // Function to run when done with the workflow
+                done,
+
+                // Function to run whenever a new stream of data comes accross STDOUT
+                function(data) {
+                    return data.includes('[ERROR] Error starting networking subsystem!');
+                }
+            );
+        });
+    });
+
+    /**
      * DHCP tests
      **/
     describe('DHCP', function() {
@@ -124,22 +158,6 @@ describe('Maestro Config', function() {
                 function(data) {
                     return data.includes('Static address set on ' + this[1].if_name + ' of ' + this[1].ipv4_addr);
                 }.bind(view.network.interfaces)
-            );
-        });
-
-        it('should disable DHCP when no networking configuration is specified in the configuration file provided to maestro', function(done) {
-            this.timeout(timeout);
-            this.skip(); // Currently doesn't support not having a network configuration
-            maestro_commands.run_shell(Commands.list.ip_flush, null);
-            maestro_commands.maestro_workflow('config_end: true',
-
-                // Function to run when done with the workflow
-                done,
-
-                // Function to run whenever a new stream of data comes accross STDOUT
-                function(data) {
-                    return data.includes('Static address set on');
-                }
             );
         });
     });

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -15,7 +15,7 @@ go get github.com/armPelionEdge/maestro || true
 
 # Go to newly created maestro directory
 cd $MAESTRO_SRC
-git checkout dev
+git checkout $(cat /tmp/githash.txt)
 
 # Build maestro dependencies
 ./build-deps.sh

--- a/vagrant/maestro.config
+++ b/vagrant/maestro.config
@@ -1,13 +1,13 @@
 network:
     interfaces:
         - if_name: eth1
-          exists: replace
+          existing: override
           dhcpv4: false
           ipv4_addr: 10.0.103.103
           ipv4_mask: 24
           hw_addr: "{{ARCH_ETHERNET_MAC}}"
         - if_name: eth2
-          exists: replace
+          existing: override
           dhcpv4: false
           ipv4_addr: 10.0.102.102
           ipv4_mask: 24


### PR DESCRIPTION
If no network configuration option exists in maestro.config, do not
run any logic to setup network interfaces.

Existing code was segfaulting because of a lack of network objects

Add system tests to check if maestro is still running and doesn't
segfault