### PR TITLE
Local development workflow improvements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,5 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
-system('git rev-parse HEAD > vagrant/githash.txt')
 
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/xenial64"
@@ -14,7 +13,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision :reload
   config.vm.provision "file", source: "vagrant/maestro.config", destination: "/tmp/maestro.config"
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
-  config.vm.provision "file", source: "vagrant/githash.txt", destination: "/tmp/githash.txt"
   config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
   config.vm.provision "file", source: "vagrant/docker-compose.yaml", destination: "/tmp/docker-compose.yaml"
   config.vm.provision "file", source: "patches/0001-PATCH-Fake-devicedb-running-on-local-machine.patch", destination: "/tmp/0001-PATCH-Fake-devicedb-running-on-local-machine.patch"

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# exit on error to make errors more visible
+set -e
+
 # Load go environment variables
 . /etc/profile.d/envvars.sh
 

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -26,11 +26,17 @@ git remote show vagranthost &>/dev/null || git remote add vagranthost ${MAESTRO_
 git fetch vagranthost
 git checkout $(git -C ${MAESTRO_SYNC_SRC} rev-parse HEAD)
 
-# Build maestro dependencies
-./build-deps.sh
-
 # Apply maestro patch
 git am patches/0001-PATCH-Fake-devicedb-running-on-local-machine.patch || git am --abort
+
+# apply any uncommitted changes from the synced folder
+if ! git -C ${MAESTRO_SYNC_SRC} diff --quiet; then
+    git reset --hard HEAD
+    git -C ${MAESTRO_SYNC_SRC} diff | git apply
+fi
+
+# Build maestro dependencies
+./build-deps.sh
 
 # Build maestro
 DEBUG=1 DEBUG2=1 ./build.sh

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -13,9 +13,15 @@ git config --global url.git@github.com:.insteadOf https://github.com/
 # Import GO project maestro
 go get github.com/armPelionEdge/maestro || true
 
-# Go to newly created maestro directory
+# Go to newly created maestro directory to check out the
+# proper version
 cd $MAESTRO_SRC
-git checkout $(cat /tmp/githash.txt)
+# Add the locally synced maestro folder as a remote.  This folder
+# is synced from the host system into the VM by Vagrant.
+MAESTRO_SYNC_SRC=/vagrant
+git remote add vagranthost ${MAESTRO_SYNC_SRC}
+git fetch vagranthost
+git checkout $(git -C ${MAESTRO_SYNC_SRC} rev-parse HEAD)
 
 # Build maestro dependencies
 ./build-deps.sh


### PR DESCRIPTION
This set of commits allows a user to work out of the host system's maestro folder while using Vagrant to build and rebuild those changes.

The dev workflow is now:
1. clone maestro on the host system
2. vagrant up
3. vagrant ssh -c "build_maestro"
4. make local changes on the host system.  this can include new commits or just leave things uncommitted.
5. repeat from step 3 until finished
