### PR TITLE
greasego: build: run go-build on project folder

### DIFF
--- a/vendor/github.com/armPelionEdge/greasego/build.sh
+++ b/vendor/github.com/armPelionEdge/greasego/build.sh
@@ -97,8 +97,8 @@ if [ "$1" != "preprocess_only" ]; then
 	else
 		make bindings.a
 	fi
-	go build github.com/armPelionEdge/greasego
-	go install github.com/armPelionEdge/greasego
+	go build
+	go install
 
 	popd
 fi


### PR DESCRIPTION
NOTE: Located on the `modify-filter` branch but this commit should go on dev ASAP as we need it for `snap-pelion-edge`

calling go-build on a package name seems to have the effect
of re-cloning the package in GOPATH which isn't really what we
want.  we want to build the source code in the local directory.