### PR TITLE
Do not use /tmp maestro.config in build script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: "~/.ssh/id_rsa.pub"
   config.vm.provision :shell, path: "vagrant/provision.sh"
   config.vm.provision :reload
-  config.vm.provision "file", source: "vagrant/maestro.config", destination: "/tmp/maestro.config"
   config.vm.provision "file", source: "vagrant/build.sh", destination: "/tmp/build_maestro"
   config.vm.provision "shell", inline: "mv /tmp/build_maestro /usr/sbin/build_maestro; chmod +x /usr/sbin/build_maestro"
   config.vm.provision "file", source: "vagrant/docker-compose.yaml", destination: "/tmp/docker-compose.yaml"

--- a/vagrant/build.sh
+++ b/vagrant/build.sh
@@ -94,7 +94,7 @@ if [ ! -f maestro.config ]; then
     SYMPHONY_CLIENT_CRT=$(cat $MAESTRO_CERTS/device_cert.pem)
     SYMPHONY_CLIENT_KEY=$(cat $MAESTRO_CERTS/device_private_key.pem)
 
-    mv /tmp/maestro.config maestro.config
+    cp /vagrant/vagrant/maestro.config maestro.config
     sed -i "s|{{DEVICE_ID}}|$DEVICE_ID|g" maestro.config
     sed -i "s|{{DEVICEDB_SRC}}|$DEVICEDB_SRC|g" maestro.config
 


### PR DESCRIPTION
Use the synced folder /vagrant instead

Prevents problems with having to re-provision just to get a new
maestro.config file