### PR TITLE
fix maestro build on arm

### DIFF
--- a/vendor/github.com/armPelionEdge/greasego/src/bindings_amd64.go
+++ b/vendor/github.com/armPelionEdge/greasego/src/bindings_amd64.go
@@ -824,7 +824,8 @@ func GetAllTargetsAndFilters() ([]GreaseLibTargetOpts, []GreaseLibFilter) {
 	count := C.GreaseLib_getFilters(&cfilters)
 	if count > 0 {
 		defer C.free(unsafe.Pointer(cfilters))
-		cfiltersSlice = (*[1 << 30]C.GreaseLibFilter)(unsafe.Pointer(cfilters))[:count:count]
+		// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
+		cfiltersSlice = (*[1 << 22]C.GreaseLibFilter)(unsafe.Pointer(cfilters))[:count:count]
 	}
 
 	for _, cfilter := range cfiltersSlice {

--- a/vendor/github.com/armPelionEdge/greasego/src/bindings_other.go
+++ b/vendor/github.com/armPelionEdge/greasego/src/bindings_other.go
@@ -810,7 +810,8 @@ func GetAllTargetsAndFilters() ([]GreaseLibTargetOpts, []GreaseLibFilter) {
 	count := C.GreaseLib_getFilters(&cfilters)
 	if count > 0 {
 		defer C.free(unsafe.Pointer(cfilters))
-		cfiltersSlice = (*[1 << 30]C.GreaseLibFilter)(unsafe.Pointer(cfilters))[:count:count]
+		// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
+		cfiltersSlice = (*[1 << 22]C.GreaseLibFilter)(unsafe.Pointer(cfilters))[:count:count]
 	}
 
 	for _, cfilter := range cfiltersSlice {


### PR DESCRIPTION
fixes the following error on meta-pelion-edge builds for the Raspberry
Pi platform:

.../bindings_other.go:815:21: type [1073741824]_Ctype_struct___2 larger than address space
.../bindings_other.go:815:21: type [1073741824]_Ctype_struct___2 too large

The same fix was applied to the amd bindings file for consistency.