### PR TITLE
Config changes

### DIFF
--- a/docs/maestro_config.md
+++ b/docs/maestro_config.md
@@ -27,6 +27,7 @@ network:
 ```
 - if_name: eth1
   existing: override
+  clear_addresses: true
   dhcpv4: false
   ipv4_addr: 10.0.103.103
   ipv4_mask: 24
@@ -36,6 +37,7 @@ network:
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
 * `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
+* `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface
 * `ipv4_mask` - REQUIRED. IP mask to use for the subnet
@@ -46,6 +48,7 @@ Breakdown:
 ```
 - if_name: eth1
   existing: override
+  clear_addresses: true
   dhcpv4: false
   ipv4_addr: 10.0.103.103
   ipv4_mask: 24
@@ -55,6 +58,7 @@ Breakdown:
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
 * `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
+* `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface
 * `ipv4_mask` - REQUIRED. IP mask to use for the subnet
@@ -205,6 +209,10 @@ Breakdown:
 * `vm_stats` - Memory statistics
 * `disk_stats` - Disk statistics
 
+How to Disable System Stats:
+* Remove the System Stats section from the config file
+* Add "disable_sys_stats: true" to the Symphony section in the config file
+
 ## config_end
 
 You must put `config_end: true` at the end of your `maestro.config`
@@ -217,12 +225,14 @@ network:
     interfaces:
         - if_name: eth1
           existing: override
+          clear_addresses: true
           dhcpv4: false
           ipv4_addr: 10.0.103.103
           ipv4_mask: 24
           hw_addr: "{{ARCH_ETHERNET_MAC}}"
         - if_name: eth2
           existing: override
+          clear_addresses: true
           dhcpv4: false
           ipv4_addr: 10.0.102.102
           ipv4_mask: 24
@@ -241,6 +251,7 @@ sys_stats: # system stats intervals
     every: "30s"
     name: disk
 symphony:
+    disable_sys_stats: false
     sys_stats_count_threshold: 15     # send if you have 15 or more stats queued
     sys_stats_time_threshold: 120000  # every 120 seconds send stuff, no matter what
     client_cert: {{SYMPHONY_CLIENT_CRT}}

--- a/docs/maestro_config.md
+++ b/docs/maestro_config.md
@@ -36,7 +36,7 @@ network:
 
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
-* `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
+* `existing` - REQUIRED. Tells Maestro to `replace` or `override` the existing saved interface
 * `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface
@@ -57,7 +57,7 @@ Breakdown:
 
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
-* `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
+* `existing` - REQUIRED. Tells Maestro to `replace` or `override` the existing saved interface
 * `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -2145,8 +2145,12 @@ func InitNetworkManager(networkconfig *maestroSpecs.NetworkConfigPayload, ddbcon
 
 	//Setup the config with the given network config
 	if inst.networkConfig != nil {
-		log.MaestroInfof("NetworkManager: Submit config read from config file\n")
-		inst.submitConfig(inst.networkConfig)
+		if inst.networkConfig.Disable == false {
+			log.MaestroInfof("NetworkManager: Submit config read from config file\n")
+			inst.submitConfig(inst.networkConfig)
+		} else {
+			return errors.New("NetworkManager: Network configuration Disable flag set to true")
+		}
 	} else {
 		return errors.New("NetworkManager: No network configuration set, unable to cofigure network")
 	}

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -690,7 +690,7 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 				}
 
 			} else { // else do nothingm db has priority
-				//                this.byInterfaceName.Set(ifname,unsafe.Pointer(ret))
+				this.byInterfaceName.Store(ifname, &storedifconfig)
 			}
 		}
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -73,7 +73,7 @@ describe('Maestro Config', function() {
             let view = {
                 network: {
                     interfaces: [
-                        {if_name: 'eth1', existing: 'replace', dhcpv4: true}
+                        {if_name: 'eth1', clear_addresses: true, existing: 'replace', dhcpv4: true}
                     ],
                 },
                 config_end: true
@@ -107,7 +107,7 @@ describe('Maestro Config', function() {
             let view = {
                 network: {
                     interfaces: [
-                        {if_name: 'eth1', existing: 'replace', dhcpv4: false, ipv4_addr: '10.123.123.123', ip_mask: 24}
+                        {if_name: 'eth1', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.123.123.123', ipv4_mask: 24}
                     ],
                 },
                 config_end: true
@@ -141,8 +141,8 @@ describe('Maestro Config', function() {
             let view = {
                 network: {
                     interfaces: [
-                        {if_name: 'eth1', existing: 'replace', dhcpv4: false, ipv4_addr: '10.99.99.99', ip_mask: 24},
-                        {if_name: 'eth2', existing: 'replace', dhcpv4: false, ipv4_addr: '10.88.88.88', ip_mask: 24}
+                        {if_name: 'eth1', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.99.99.99', ipv4_mask: 24},
+                        {if_name: 'eth2', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.88.88.88', ipv4_mask: 24}
                     ],
                 },
                 config_end: true
@@ -201,7 +201,7 @@ describe('Maestro Config', function() {
             let view = {
                 network: {
                     interfaces: [
-                        {if_name: 'eth1', existing: 'replace', dhcpv4: true}
+                        {if_name: 'eth1', clear_addresses: true, existing: 'replace', dhcpv4: true}
                     ],
                 },
                 sys_stats: {
@@ -242,7 +242,7 @@ describe('Maestro Config', function() {
             let view = {
                 network: {
                     interfaces: [
-                        {if_name: 'eth1', existing: 'replace', dhcpv4: true}
+                        {if_name: 'eth1', clear_addresses: true, existing: 'replace', dhcpv4: true}
                     ],
                 },
                 sys_stats: {
@@ -296,8 +296,8 @@ describe('Maestro API', function() {
                 sysLogSocket: '/run/systemd/journal/syslog',
                 network: {
                     interfaces: [
-                        {if_name: 'eth1', existing: 'replace', dhcpv4: false, ipv4_addr: '10.99.99.99', ip_mask: 24},
-                        {if_name: 'eth2', existing: 'replace', dhcpv4: false, ipv4_addr: '10.88.88.88', ip_mask: 24}
+                        {if_name: 'eth1', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.99.99.99', ipv4_mask: 24},
+                        {if_name: 'eth2', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.88.88.88', ipv4_mask: 24}
                     ]
                 },
                 sys_stats: {
@@ -528,8 +528,8 @@ describe('DeviceDB', function() {
                     let view = {
                         network: {
                             interfaces: [
-                                {if_name: 'eth1', existing: 'replace', dhcpv4: false, ipv4_addr: '10.77.77.77', ip_mask: 24},
-                                {if_name: 'eth2', existing: 'replace', dhcpv4: false, ipv4_addr: '10.66.66.66', ip_mask: 24}
+                                {if_name: 'eth1', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.77.77.77', ipv4_mask: 24},
+                                {if_name: 'eth2', existing: 'replace', clear_addresses: true, dhcpv4: false, ipv4_addr: '10.66.66.66', ipv4_mask: 24}
                             ]
                         },
                         devicedb_conn_config: {
@@ -582,7 +582,7 @@ describe('DeviceDB', function() {
         it('should set the IP address of the second network adapter', function(done) {
             this.timeout(timeout);
             this.done = done;
-            devicedb_set_ip_address(this, 'eth1', '10.125.125.125');
+            devicedb_set_ip_address(this, 'eth2', '10.125.125.125');
         });
 
         it('should change the IP address of the second network adapter', function(done) {

--- a/vendor/github.com/armPelionEdge/maestroSpecs/networking.go
+++ b/vendor/github.com/armPelionEdge/maestroSpecs/networking.go
@@ -150,6 +150,9 @@ type NetIfConfigPayload struct {
 // }
 
 type NetworkConfigPayload struct {
+	// If the flag is "disable : false" then maestro will do networking.  If the flag is "disable : true" then maestro will not do networking.
+	Disable bool `yaml:"disable" json:"disable" netgroup:"config_network"`
+
 	// an array of network interfaces to configure
 	Interfaces []*NetIfConfigPayload `yaml:"interfaces" json:"interfaces" netgroup:"if"`
 


### PR DESCRIPTION
This PR fixes the ethernet interface not coming up issue.
https://jira.arm.com/browse/PELEDGE19-2507

When the "existing" field is not set in the interface section, maestro will go back to the interface config that is stored in it's local database (networkConfigdb). Hence if the interface config needs to be changed either through devicedb or config file, setting the "existing" field is mandatory.