### PR TITLE
Fix interfacebug

### DIFF
--- a/docs/maestro_config.md
+++ b/docs/maestro_config.md
@@ -36,7 +36,7 @@ network:
 
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
-* `existing` - REQUIRED. Tells Maestro to `replace` or `override` the existing saved interface
+* `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
 * `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface
@@ -57,7 +57,7 @@ Breakdown:
 
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
-* `existing` - REQUIRED. Tells Maestro to `replace` or `override` the existing saved interface
+* `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
 * `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface

--- a/docs/maestro_config.md
+++ b/docs/maestro_config.md
@@ -36,7 +36,7 @@ network:
 
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
-* `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
+* `existing` - REQUIRED. Tells Maestro to `replace` or `override` the existing saved interface
 * `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface
@@ -57,7 +57,7 @@ Breakdown:
 
 Breakdown:
 * `if_name` - REQUIRED. Name of the interface Maestro will modify
-* `existing` - OPTIONAL. Tells Maestro to `replace` or `override` the existing saved interface
+* `existing` - REQUIRED. Tells Maestro to `replace` or `override` the existing saved interface
 * `clear_addresses` - REQUIRED. Clears any existing addresses assigned to the interface before setting up the specified addresses
 * `dhcpv4` - REQUIRED. `false` for static interfaces
 * `ipv4_addr` - REQUIRED. IP address to assign to the interface

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -690,7 +690,7 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 				}
 
 			} else { // else do nothingm db has priority
-				//                this.byInterfaceName.Set(ifname,unsafe.Pointer(ret))
+				this.byInterfaceName.Store(ifname, &storedifconfig)
 			}
 		}
 


### PR DESCRIPTION
This PR fixes the ethernet interface not coming up issue.
https://jira.arm.com/browse/PELEDGE19-2507

When the "existing" field is not set in the interface section, maestro will go back to the interface config that is stored in it's local database (networkConfigdb). 