### PR TITLE
greaseLib: defaultTarget print to stderr not TTY

### DIFF
--- a/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.cc
+++ b/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/logger.cc
@@ -650,7 +650,11 @@ void GreaseLogger::targetReady(bool ready, _errcmn::err_ev &err, logTarget *t) {
 	if(t->myId == DEFAULT_TARGET && info) delete info;
 }
 
-
+static void defaultTargetCallbackStderr(GreaseLibError *err, void *d, uint32_t targetId)
+{
+	GreaseLibBuf *buf = (GreaseLibBuf *)d;
+	fprintf(stderr, "%s", buf->data);
+}
 
 void GreaseLogger::setupDefaultTarget(actionCB cb, target_start_info *i) {
 	delim_data defaultdelim;
@@ -665,7 +669,10 @@ void GreaseLogger::setupDefaultTarget(actionCB cb, target_start_info *i) {
 //	err.setError(65001,"Test");
 //	cb(this,err,i);
 	// << end test
-	new ttyTarget(size, DEFAULT_TARGET, this, targetReady,std::move(defaultdelim), i);
+	auto targ = new callbackTarget(size, DEFAULT_TARGET, GreaseLogger::LOGGER, targetReady, std::move(defaultdelim), i);
+	_errcmn::err_ev err;
+	targ->setCallback(defaultTargetCallbackStderr);
+	targ->readyCB(true, err, targ);
 }
 
 


### PR DESCRIPTION
The controlling terminal TTY can't be redirected using standard
file descriptor redirection techniques and some of the log info
is very valuable.