### PR TITLE
Attempt type assertion only if key exists in processIndexByPid map

### DIFF
--- a/processes/processMgmt.go
+++ b/processes/processMgmt.go
@@ -198,7 +198,9 @@ type ProcessRecord struct {
 func GetTrackedProcessByPid(pid int) (ret *ProcessRecord, ok bool) {
 	var val interface{}
 	val, ok = processIndexByPid.Load(pid)
-	ret = val.(*ProcessRecord)
+	if ok {
+		ret = val.(*ProcessRecord)
+	}
 	return
 }
 


### PR DESCRIPTION
`name: devicedb
panic: interface conversion: interface {} is nil, not *processes.ProcessRecord
goroutine 16 [running]:
github.com/armPelionEdge/maestro/processes.GetTrackedProcessByPid(0x106b, 0xbfa9fe04, 0xbb1d6872)`

This error is fixed by attempting type assertion only if key exists in processIndexByPid map