### PR TITLE
Submit dns fix

### DIFF
--- a/networking/manager.go
+++ b/networking/manager.go
@@ -742,7 +742,9 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 	this.networkConfig = config
 
 	//reset all current config if this function is called again
-	this.resetLinks()
+	if len(config.Interfaces) > 0 {
+		this.resetLinks()
+	}
 
 	// NOTE: this is only for the config file initial start
 	// NOTE: the database must already be loaded and read

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -518,9 +518,6 @@ func (this *networkManagerInstance) applyDNS(config maestroSpecs.NetworkConfigPa
 
 	//make the config active
 	instance.submitConfig(&config)
-
-	//write out the dns files
-	instance.finalizeDns()
 }
 
 /*
@@ -859,6 +856,9 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 	//store to active config
 	instance.networkConfig.Nameservers = nil
 	instance.networkConfig.Nameservers = append(instance.networkConfig.Nameservers, storedconfig...)
+
+	//write out the dns files
+	instance.finalizeDns()
 }
 
 func (this *networkManagerInstance) getIfFromDb(ifname string) (ret *NetworkInterfaceData) {


### PR DESCRIPTION
Submitting updates with only DNS changes no longer destroys existing
network interfaces.