### PR TITLE
v2.7.1

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -50,7 +50,6 @@ func SetLoggingLevel(ll string) {
 var goReady = false
 var disabled = false
 
-// DisableGreaseLog is used by test programs
 func DisableGreaseLog() {
 	disabled = true
 }

--- a/logconfig/manager.go
+++ b/logconfig/manager.go
@@ -233,6 +233,7 @@ func (logManager *logManagerInstance) submitConfigAndSync(config []maestroSpecs.
 	}
 }
 
+// stores the config parameter to the local DB and updates the running config
 func (logManager *logManagerInstance) submitConfig(config []maestroSpecs.LogTarget) {
 	log.MaestroInfof("in submitConfig\n")
 	logManager.logConfigRunning = config

--- a/maestro/main.go
+++ b/maestro/main.go
@@ -101,7 +101,12 @@ func main() {
 	versionFlag := flag.Bool("version", false, "Dump version information")
 	debugServerFlag := flag.Bool("debug_loopback", true, "Start a debug loopback on http://127.0.0.1:6060")
 	debugMemory := flag.Bool("debug_mem", true, "Debugging memory stats")
+	logToStdout := flag.Bool("log_to_stdout", false, "Send maestro's log messages to stdout instead of directly to GreaseLog")
 	flag.Parse()
+
+	if *logToStdout {
+		Log.DisableGreaseLog()
+	}
 
 	debugging.DebugPprof(*debugServerFlag)
 	if *debugMemory {

--- a/maestroConfig/deviceDBConfigMonitor.go
+++ b/maestroConfig/deviceDBConfigMonitor.go
@@ -181,7 +181,7 @@ func CreateDDBRelayConfigClient(ddbConnConfig *DeviceDBConnConfig) (*DDBRelayCon
 		if ddbConfigClient.IsAvailable() {
 			break
 		} else {
-			log.MaestroWarnf("maestroConfig: devicedb is not running. retrying in %d seconds", loopWaitTime)
+			log.MaestroWarnf("maestroConfig: devicedb is not running. retrying in %d seconds\n", loopWaitTime)
 			time.Sleep(time.Second * time.Duration(loopWaitTime))
 			totalWaitTime += loopWaitTime
 			//If we cant connect in first 6 minutes, check much less frequently for next 24 hours hoping that devicedb may come up later.
@@ -192,7 +192,7 @@ func CreateDDBRelayConfigClient(ddbConnConfig *DeviceDBConnConfig) (*DDBRelayCon
 
 		//After 24 hours just assume its never going to come up stop waiting for it and break the loop
 		if totalWaitTime >= MAX_DEVICEDB_WAIT_TIME_IN_SECS {
-			log.MaestroErrorf("maestroConfig: devicedb is not running, cannot fetch config from devicedb")
+			log.MaestroErrorf("maestroConfig: devicedb is not running, cannot fetch config from devicedb\n")
 			return nil, errors.New("devicedb is not running, cannot fetch config from devicedb")
 		}
 	}
@@ -242,10 +242,10 @@ type DDBConfig struct {
 func (rcc *DDBRelayConfigClient) IsAvailable() bool {
 	_, err := rcc.Client.Get(context.Background(), rcc.Bucket, []string{"NULL"})
 	if err != nil {
-		log.MaestroErrorf("DDBRelayConfigClient.IsAvailable(): false, Error: %v", err)
+		log.MaestroErrorf("DDBRelayConfigClient.IsAvailable(): false, Error: %v\n", err)
 		return false
 	}
-	log.MaestroInfo("DDBRelayConfigClient.IsAvailable(): true")
+	log.MaestroInfo("DDBRelayConfigClient.IsAvailable(): true\n")
 	return true
 }
 
@@ -263,7 +263,7 @@ func (ddbConfig *DDBConfig) Get(t interface{}) (err error) {
 	//get given key from devicedb
 	configEntries, err := ddbConfig.ConfigClient.Client.Get(context.Background(), ddbConfig.ConfigClient.Bucket, []string{ddbConfig.DeviceDBKey()})
 	if err != nil {
-		log.MaestroErrorf("DDBConfig.Get(): Failed to get the matched config from the devicedb. Error: %v", err)
+		log.MaestroErrorf("DDBConfig.Get(): Failed to get the matched config from the devicedb. Error: %v\n", err)
 		return err
 	}
 
@@ -321,13 +321,13 @@ func (ddbConfig *DDBConfig) Put(t interface{}) (err error) {
 
             err = ddbConfig.ConfigClient.Client.Batch(ctx, ddbConfig.Bucket, *devicedbClientBatch)
             if err != nil {
-                log.MaestroErrorf("DDBConfig.Put(): %v", err)
+                log.MaestroErrorf("DDBConfig.Put(): %v\n", err)
                 return err
             }
         }
 	} else {
 		err = errors.New("Put: Invalid argument")
-		log.MaestroErrorf("DDBConfig.Put() Invalid argument. Error %v", err)
+		log.MaestroErrorf("DDBConfig.Put() Invalid argument. Error %v\n", err)
 	}
 	return err
 }
@@ -341,7 +341,7 @@ func (ddbConfig *DDBConfig) Delete() (err error) {
 	//log.MaestroErrorf("DDBConfig.Delete() Deleting key: %s", ddbConfig.Key)
 	err = ddbConfig.ConfigClient.Client.Batch(ctx, ddbConfig.Bucket, *devicedbClientBatch)
 	if err != nil {
-		log.MaestroErrorf("DDBConfig.Delete(): %v", err)
+		log.MaestroErrorf("DDBConfig.Delete(): %v\n", err)
 	}
 
 	return
@@ -389,12 +389,12 @@ func (watcher *DDBWatcher) Next(t interface{}) bool {
 		//log.MaestroWarnf("DDBConfig.Next() Updates triggered")
 
 		if !ok {
-			log.MaestroWarnf("DDBConfig.Next() Updates channel closed, no need to listen anymore")
+			log.MaestroWarnf("DDBConfig.Next() Updates channel closed, no need to listen anymore\n")
 			break
 		}
 
 		if u == "" {
-			log.MaestroWarnf("DDBWatcher.Next() found that the key has been deleted")
+			log.MaestroWarnf("DDBWatcher.Next() found that the key has been deleted\n")
 			return false
 		}
 
@@ -403,7 +403,7 @@ func (watcher *DDBWatcher) Next(t interface{}) bool {
 		// we will skip it util we could parse it successfully
 		err := json.Unmarshal([]byte(u), &t)
 		if err != nil {
-			log.MaestroErrorf("DDBWatcher.Next() failed to parse the update into expected format. Error: %v", err)
+			log.MaestroErrorf("DDBWatcher.Next() failed to parse the update into expected format. Error: %v\n", err)
 			continue
 		}
 
@@ -422,7 +422,7 @@ func (watcher *DDBWatcher) Next(t interface{}) bool {
 
 // For the error channel, it will just simply print out the logs from the devicedb
 func (watcher *DDBWatcher) handleWatcher() {
-	log.MaestroDebugf("DDBWatcher.handleWatcher(): bucket:%s key:%s", watcher.Config.ConfigClient.Bucket, watcher.Config.Key)
+	log.MaestroDebugf("DDBWatcher.handleWatcher(): bucket:%s key:%s\n", watcher.Config.ConfigClient.Bucket, watcher.Config.Key)
 
 	//watch the given devicedb key
 	updates, errors := watcher.Config.ConfigClient.Client.Watch(context.Background(), watcher.Config.ConfigClient.Bucket, []string{watcher.Config.DeviceDBKey()}, []string{}, 0)
@@ -446,7 +446,7 @@ func (watcher *DDBWatcher) handleWatcher() {
 		case update, ok := <-updates:
 
 			if !ok {
-				log.MaestroErrorf("DDBConfig.handleWatcher() the DeviceDB monitor encountered a protocol error and have already cancelled the watcher")
+				log.MaestroErrorf("DDBConfig.handleWatcher() the DeviceDB monitor encountered a protocol error and have already cancelled the watcher\n")
 				break
 			}
 
@@ -460,7 +460,7 @@ func (watcher *DDBWatcher) handleWatcher() {
 			configLen = len(sortableConfigs)
 			if configLen == 0 {
 				log.MaestroDebugf("Got a unknown config: %+v\n", sortableConfigs[0])
-				log.MaestroInfof("DDBConfig.handleWatcher(): configLen == 0")
+				log.MaestroInfof("DDBConfig.handleWatcher(): configLen == 0\n")
 				watcher.Updates <- ""
 				continue
 			}
@@ -474,20 +474,20 @@ func (watcher *DDBWatcher) handleWatcher() {
 					watcher.Updates <- string(bodyJSON)
 				}
 			} else {
-				log.MaestroWarnf("DDBConfig.handleWatcher(): json.Unmarshal error: %v configs:%v", err, sortableConfigs[0])
+				log.MaestroWarnf("DDBConfig.handleWatcher(): json.Unmarshal error: %v configs:%v\n", err, sortableConfigs[0])
 			}
 
 		case err, ok := <-errors:
 			log.MaestroErrorf("DDBConfig.handleWatcher() received an error from the watcher. Error: %v", err)
 			if !ok {
-				log.MaestroWarnf("DDBConfig.handleWatcher() the DeviceDB monitor encounter a protocol error and have already cancelled the watcher")
+				log.MaestroWarnf("DDBConfig.handleWatcher() the DeviceDB monitor encounter a protocol error and have already cancelled the watcher\n")
 				break
 			}
 
 		case _, ok := <-watcher.handleWatcherControl:
-			log.MaestroErrorf("DDBConfig.handleWatcher() -watcher.handleWatcherControl triggered")
+			log.MaestroErrorf("DDBConfig.handleWatcher() -watcher.handleWatcherControl triggered\n")
 			if !ok {
-				log.MaestroWarnf("DDBConfig.handleWatcher() got channel closed, no need to listen anymore")
+				log.MaestroWarnf("DDBConfig.handleWatcher() got channel closed, no need to listen anymore\n")
 				break
 			}
 		}

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -215,7 +215,6 @@ type networkManagerInstance struct {
 	networkConfigDB *stow.Store
 	// internal structures
 	byInterfaceName    sync.Map // map of identifier to struct -> 'eth2':&networkInterfaceData{}
-	indexToName        sync.Map
 	watcherWorkChannel chan networkThreadMessage
 
 	newInterfaceMutex sync.Mutex
@@ -225,7 +224,8 @@ type networkManagerInstance struct {
 	interfaceThreadCount      int
 	interfaceThreadCountMutex sync.Mutex
 	threadCountChan           chan networkThreadMessage
-	networkConfig             *maestroSpecs.NetworkConfigPayload
+	activeNetworkConfig       *maestroSpecs.NetworkConfigPayload
+	futureNetworkConfig       *maestroSpecs.NetworkConfigPayload
 
 	//Configs to be used for connecting to devicedb
 	ddbConnConfig    *maestroConfig.DeviceDBConnConfig
@@ -247,6 +247,33 @@ type networkManagerInstance struct {
 const DDB_NETWORK_CONFIG_NAME string = "MAESTRO_NETWORK_CONFIG_ID"
 const DDB_NETWORK_CONFIG_COMMIT_FLAG string = "MAESTRO_NETWORK_CONFIG_COMMIT_FLAG"
 const DDB_NETWORK_CONFIG_CONFIG_GROUP_ID string = "netgroup"
+
+// Helpers for building up a new networkConfig
+func (this *networkManagerInstance) StartFutureConfig() error {
+	if nil != this.futureNetworkConfig {
+		return errors.New("Change already in progress")
+	}
+	this.futureNetworkConfig = new(maestroSpecs.NetworkConfigPayload)
+	// seed it with the current settings for implementation reasons in the
+	// devicedb monitor code, for example to make sure that the Interfaces
+	// array is the proper length
+	this.GetNetworkConfig(this.futureNetworkConfig)
+	return nil
+}
+
+func (this *networkManagerInstance) GetFutureConfig() *maestroSpecs.NetworkConfigPayload {
+	return this.futureNetworkConfig
+}
+
+func (this *networkManagerInstance) AbortFutureConfig() {
+	this.futureNetworkConfig = nil
+}
+
+func (this *networkManagerInstance) ApplyFutureConfig() error {
+	this.submitConfig(this.futureNetworkConfig)
+	this.futureNetworkConfig = nil
+	return this.setupInterfaces()
+}
 
 func (inst *networkManagerInstance) getNewDnsBufferForInterface(ifname string) (ret *dnsBuf) {
 	ret = new(dnsBuf)
@@ -274,8 +301,8 @@ func (inst *networkManagerInstance) removeDnsBufferForInterface(ifname string) {
 // or the alternate (AltResolvConf) if set
 func (inst *networkManagerInstance) finalizeDns() (err error) {
 	path := resolvConfPath
-	if len(inst.networkConfig.AltResolvConf) > 0 {
-		path = inst.networkConfig.AltResolvConf
+	if len(inst.activeNetworkConfig.AltResolvConf) > 0 {
+		path = inst.activeNetworkConfig.AltResolvConf
 	}
 
 	var file *os.File
@@ -296,8 +323,8 @@ func (inst *networkManagerInstance) finalizeDns() (err error) {
 	writer.WriteString(s)
 
 	// if the config had any stated name servers, add them first
-	if len(inst.networkConfig.Nameservers) > 0 {
-		for _, ipS := range inst.networkConfig.Nameservers {
+	if len(inst.activeNetworkConfig.Nameservers) > 0 {
+		for _, ipS := range inst.activeNetworkConfig.Nameservers {
 			// check to make sure its a valid IP, by parsing it using the go net package
 			ip := net.ParseIP(ipS)
 			if ip != nil {
@@ -337,8 +364,8 @@ func (inst *networkManagerInstance) finalizeDns() (err error) {
 	// if we are writing dns config to a file other than /etc/resolv.conf, that usually
 	// means we are running on a system that uses resolvconf as a means to integrate multiple
 	// services that need to add dns config to /etc/resolv.conf without stomping on each other.
-	if len(inst.networkConfig.AltResolvConf) > 0 {
-		dnsconfig, err2 := ioutil.ReadFile(inst.networkConfig.AltResolvConf)
+	if len(inst.activeNetworkConfig.AltResolvConf) > 0 {
+		dnsconfig, err2 := ioutil.ReadFile(inst.activeNetworkConfig.AltResolvConf)
 		if err2 != nil {
 			log.MaestroErrorf("NetworkManager: failed to read DNS resolv.conf")
 			return
@@ -458,7 +485,7 @@ func (this *networkManagerInstance) GetDNS() ([]string, error) {
 	//var err error
 	dns := make([]string, 0)
 
-	dns = append(dns, this.networkConfig.Nameservers...)
+	dns = append(dns, this.activeNetworkConfig.Nameservers...)
 
 	return dns, nil
 }
@@ -480,7 +507,7 @@ func (this *networkManagerInstance) AddDNS(dns string) error {
 	var newConfig maestroSpecs.NetworkConfigPayload
 
 	//update the nameservers in the config
-	newConfig.Nameservers = append(this.networkConfig.Nameservers, dns)
+	newConfig.Nameservers = append(this.activeNetworkConfig.Nameservers, dns)
 
 	//make replace
 	newConfig.Existing = "override"
@@ -546,8 +573,11 @@ func indexOf(array []string, value string) int {
 */
 func (this *networkManagerInstance) applyDNS(config maestroSpecs.NetworkConfigPayload) {
 
-	//make the config active
+	// persist config to local DB
 	instance.submitConfig(&config)
+
+	// make the dns config active
+	instance.finalizeDns()
 }
 
 /*
@@ -567,7 +597,7 @@ func (this *networkManagerInstance) DeleteDNS(dns string) error {
 	var newConfig maestroSpecs.NetworkConfigPayload
 
 	//delete the nameserver in the config
-	newConfig.Nameservers = removeElement(this.networkConfig.Nameservers, dns)
+	newConfig.Nameservers = removeElement(this.activeNetworkConfig.Nameservers, dns)
 
 	newConfig.Existing = "override"
 
@@ -651,7 +681,7 @@ func GetInstance() *networkManagerInstance {
 	if instance == nil {
 		instance = newNetworkManagerInstance()
 		// provide a blank network config for now (until one is provided)
-		instance.networkConfig = new(maestroSpecs.NetworkConfigPayload)
+		instance.activeNetworkConfig = new(maestroSpecs.NetworkConfigPayload)
 		storage.RegisterStorageUser(instance)
 		// internalTicker = time.NewTicker(time.Second * time.Duration(defaults.TASK_MANAGER_CLEAR_INTERVAL))
 		// controlChan = make(chan *controlToken, 100) // buffer up to 100 events
@@ -729,12 +759,65 @@ func updateIfConfigFromStored(netdata *NetworkInterfaceData) (ok bool, err error
 	return
 }
 
+// writes the config parameter to the maestroDB and to the running config
+//
+// this function stores the new config to maestroDB and updates the network instance's
+// runtime data structures, it does not activate any of the new config on the host system
+// nor does it update DeviceDB
 func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkConfigPayload) {
-	this.networkConfig = config
 
-	// NOTE: this is only for the config file initial start
-	// NOTE: the database must already be loaded and read
-	// should only be called once. Is only called by InitNetworkManager()
+	if this.activeNetworkConfig.DontSetDefaultRoute != config.DontSetDefaultRoute {
+		this.activeNetworkConfig.DontSetDefaultRoute = config.DontSetDefaultRoute
+		log.MaestroInfof("NetworkManager: submitConfig: DontSetDefaultRoute changed to: %t\n",
+				 this.activeNetworkConfig.DontSetDefaultRoute)
+	}
+
+	if this.activeNetworkConfig.DnsIgnoreDhcp != config.DnsIgnoreDhcp {
+		this.activeNetworkConfig.DnsIgnoreDhcp = config.DnsIgnoreDhcp
+		log.MaestroInfof("NetworkManager: submitConfig: DnsIgnoreDhcp changed to: %t\n",
+				 this.activeNetworkConfig.DnsIgnoreDhcp)
+	}
+
+	if this.activeNetworkConfig.AltResolvConf != config.AltResolvConf {
+		this.activeNetworkConfig.AltResolvConf = config.AltResolvConf
+		log.MaestroInfof("NetworkManager: submitConfig: AltResolvConf changed to: %s\n",
+				 this.activeNetworkConfig.AltResolvConf)
+	}
+
+	if this.activeNetworkConfig.DnsRunLocalCaching != config.DnsRunLocalCaching {
+		this.activeNetworkConfig.DnsRunLocalCaching = config.DnsRunLocalCaching
+		log.MaestroInfof("NetworkManager: submitConfig: DnsRunLocalCaching changed to: %t\n",
+				 this.activeNetworkConfig.DnsRunLocalCaching)
+	}
+
+	if this.activeNetworkConfig.DnsForwardTo != config.DnsForwardTo {
+		this.activeNetworkConfig.DnsForwardTo = config.DnsForwardTo
+		log.MaestroInfof("NetworkManager: submitConfig: DnsForwardTo changed to: %s\n",
+				 this.activeNetworkConfig.DnsForwardTo)
+	}
+
+	if this.activeNetworkConfig.DnsRunRootLookup != config.DnsRunRootLookup {
+		this.activeNetworkConfig.DnsRunRootLookup = config.DnsRunRootLookup
+		log.MaestroInfof("NetworkManager: submitConfig: DnsRunRootLookup changed to: %t\n",
+				 this.activeNetworkConfig.DnsRunRootLookup)
+	}
+
+	if this.activeNetworkConfig.DnsHostsData != config.DnsHostsData {
+		this.activeNetworkConfig.DnsHostsData = config.DnsHostsData
+		log.MaestroInfof("NetworkManager: submitConfig: DnsHostsData changed to: %s\n",
+				 this.activeNetworkConfig.DnsHostsData)
+	}
+
+	if this.activeNetworkConfig.FallbackNameservers != config.FallbackNameservers {
+		this.activeNetworkConfig.FallbackNameservers = config.FallbackNameservers
+		log.MaestroInfof("NetworkManager: submitConfig: FallbackNameservers changed to: %s\n",
+				 this.activeNetworkConfig.FallbackNameservers)
+	}
+
+	// skip Existing
+	// skip Disable.  we don't handle the case where we enable/disable after initial startup
+
+	// update the interfaces map and maestroDB
 	for _, ifconf := range config.Interfaces {
 		log.MaestroInfof("NetworkManager: submitConfig: if %s\n", ifconf.IfName)
 		// look in database
@@ -748,26 +831,17 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 		var storedifconfig NetworkInterfaceData
 		err := this.networkConfigDB.Get(ifname, &storedifconfig)
 		if err != nil {
-			log.MaestroInfof("NetworkManager: submitConfig: Get failed: %v\n", err)
+			log.MaestroInfof("NetworkManager: submitConfig: no stored config found for interface %s: %v\n", ifname, err)
 			if err != stow.ErrNotFound {
 				log.MaestroErrorf("NetworkManager: problem with database on if %s - Get: %s\n", ifname, err.Error())
 			} else {
-				// ret = new(NetworkInterfaceData)
-				// ret.IfName = ifconf.IfName
 				newconf := newIfData(ifconf.IfName, ifconf)
 				this.byInterfaceName.Store(ifname, newconf)
+				// flush the stored config to maestroDB
 				err = this.commitInterfaceData(ifname)
 				if err != nil {
 					log.MaestroErrorf("NetworkManager: Problem (1) storing config for interface [%s]: %s\n", ifconf.IfName, err)
 				}
-				// // ret.RunningIfconfig = new(maestroSpecs.NetIfConfigPayload)
-				// // ret.RunningIfconfig.IfName = ifname
-				// ret.StoredIfconfig = new(maestroSpecs.NetIfConfigPayload)
-				// ret.StoredIfconfig.IfName = ifname
-
-				// this.byInterfaceName.Set(ifname,unsafe.Pointer(ret))
-				// this.commitInterfaceData(ifname)
-				// // this.byInterfaceName.Set(ifname,unsafe.Pointer(ret))
 			}
 		} else {
 			// entry existed, so override
@@ -775,6 +849,7 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 				// same as above, brand new
 				newconf := newIfData(ifconf.IfName, ifconf)
 				this.byInterfaceName.Store(ifname, newconf)
+				// flush to maestroDB
 				err = this.commitInterfaceData(ifname)
 				if err != nil {
 					log.MaestroErrorf("NetworkManager: Problem (2) storing config for interface [%s]: %s\n", ifconf.IfName, err)
@@ -800,7 +875,9 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 					storedifconfig.StoredIfconfig = ifconf
 				}
 				debugging.DEBUG_OUT("storedifconfig: %+v\n", storedifconfig.StoredIfconfig)
+				// copy iface config data to map for easier lookup
 				this.byInterfaceName.Store(ifname, &storedifconfig)
+				// flush to maestroDB
 				err = this.commitInterfaceData(ifname)
 				if err != nil {
 					log.MaestroErrorf("NetworkManager: Problem (3) storing config for interface [%s]: %s\n", ifconf.IfName, err)
@@ -812,9 +889,11 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 				this.byInterfaceName.Store(ifname, &storedifconfig)
 			}
 		}
-
 	}
+	// update the active interfaces array
+	this.copyNetworkConfigInterfaces(this.activeNetworkConfig, config)
 
+	// update nameservers
 	//id of the dns in db
 	dnsid := string("nameservers")
 
@@ -829,22 +908,18 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 		storedconfig = nil
 		storedconfig = append(storedconfig, config.Nameservers...)
 
-		//store name servers
+		//store name servers to maestroDB
 		this.networkConfigDB.Put(dnsid, storedconfig)
 	} else if config.Existing == "" && len(storedconfig) == 0 {
 		//write to nameservers if nothing exists
 		storedconfig = append(storedconfig, config.Nameservers...)
 
-		//store name servers
+		//store name servers to maestroDB
 		this.networkConfigDB.Put(dnsid, storedconfig)
 	}
 
-	//store to active config
-	instance.networkConfig.Nameservers = nil
-	instance.networkConfig.Nameservers = append(instance.networkConfig.Nameservers, storedconfig...)
-
-	//write out the dns files
-	instance.finalizeDns()
+	//update active config
+	this.activeNetworkConfig.Nameservers = storedconfig
 }
 
 func (this *networkManagerInstance) getIfFromDb(ifname string) (ret *NetworkInterfaceData) {
@@ -961,7 +1036,7 @@ func (this *networkManagerInstance) SetInterfaceConfigByName(ifname string, ifco
 
 func (this *networkManagerInstance) ifdown(ifname string) {
 	ifdata := this.getInterfaceData(ifname)
-	if ifdata != nil {
+	if ifdata == nil {
 		log.MaestroErrorf("NetworkManager: ifdown unknown interface: %s\n", ifname)
 		return
 	}
@@ -1056,9 +1131,9 @@ func (this *networkManagerInstance) setupInterfaces() (err error) {
 //This function calls the setupInterfaces with the current config and then start connection with devicedb by calling initDeviceDBConfig
 //Note that call to initDeviceDBConfig is done as a go routine.
 func (this *networkManagerInstance) SetupExistingInterfaces() (err error) {
-	log.MaestroInfof("NetworkManager: Setup the intfs using initial boot config first: %v:%v\n", this.networkConfig, this.networkConfig.Interfaces)
+	log.MaestroInfof("NetworkManager: Setup the intfs using initial boot config first: %v:%v\n", this.activeNetworkConfig, this.activeNetworkConfig.Interfaces)
 
-	if this.networkConfig.Disable == true {
+	if this.activeNetworkConfig.Disable == true {
 		log.MaestroInfo("NetworkManager: Network management is disabled.  No interfaces to bring up.\n")
 		return
 	}
@@ -1093,6 +1168,31 @@ func (this *networkManagerInstance) initDeviceDBConfig() error {
 	return err
 }
 
+// helper for copying the Interfaces array from one NetworkConfigPayload to another
+func (this *networkManagerInstance) copyNetworkConfigInterfaces(lhs *maestroSpecs.NetworkConfigPayload,
+								rhs *maestroSpecs.NetworkConfigPayload) {
+	if lhs == rhs {
+		log.MaestroErrorf("ERROR: copy network interfaces: passed in equal object pointers")
+		return
+	}
+	lhs.Interfaces = make([]*maestroSpecs.NetIfConfigPayload, len(rhs.Interfaces))
+	for i, v := range rhs.Interfaces {
+		lhs.Interfaces[i] = new(maestroSpecs.NetIfConfigPayload)
+		*lhs.Interfaces[i] = *v
+	}
+}
+
+// create a copy of the active network config
+func (this *networkManagerInstance) GetNetworkConfig(config *maestroSpecs.NetworkConfigPayload) {
+	// start with a shallow copy
+	*config = *this.activeNetworkConfig
+	// copy the Interfaces array
+	this.copyNetworkConfigInterfaces(config, this.activeNetworkConfig)
+	// copy the Nameservers array
+	config.Nameservers = make([]string, len(this.activeNetworkConfig.Nameservers))
+	copy(config.Nameservers, this.activeNetworkConfig.Nameservers)
+}
+
 //SetupDeviceDBConfig reads the config from devicedb and if its new it applies the new config.
 //It also sets up the config update handlers for all the tags/groups.
 func (this *networkManagerInstance) SetupDeviceDBConfig() error {
@@ -1109,8 +1209,8 @@ func (this *networkManagerInstance) SetupDeviceDBConfig() error {
 
 	err = this.ddbConfigClient.Config(DDB_NETWORK_CONFIG_NAME).Get(&ddbNetworkConfig)
 	if err != nil {
-		log.MaestroWarnf("NetworkManager: No network config found in devicedb or unable to connect to devicedb err: %v. Let's put the current running config: %v.\n", err, *this.networkConfig)
-		err = this.ddbConfigClient.Config(DDB_NETWORK_CONFIG_NAME).Put(this.networkConfig)
+		log.MaestroWarnf("NetworkManager: No network config found in devicedb or unable to connect to devicedb err: %v. Let's put the current running config: %v.\n", err, *this.activeNetworkConfig)
+		err = this.ddbConfigClient.Config(DDB_NETWORK_CONFIG_NAME).Put(this.activeNetworkConfig)
 		if err != nil {
 			log.MaestroErrorf("NetworkManager: Unable to put network config in devicedb err:%v, config will not be monitored from devicedb\n", err)
 			return errors.New(fmt.Sprintf("\nUnable to put network config in devicedb err:%v, config will not be monitored from devicedb\n", err))
@@ -1118,12 +1218,11 @@ func (this *networkManagerInstance) SetupDeviceDBConfig() error {
 	} else {
 		//We found a config in devicedb, lets try to use and reconfigure network if its an updated one
 		log.MaestroInfof("NetworkManager: Found a valid config in devicedb [%v], will try to use and reconfigure network if its an updated one\n", ddbNetworkConfig)
-		identical, _, _, err := configAna.DiffChanges(this.networkConfig, ddbNetworkConfig)
+		identical, _, _, err := configAna.DiffChanges(this.activeNetworkConfig, ddbNetworkConfig)
 		if !identical && (err == nil) {
 			//The configs are different, lets go ahead reconfigure the intfs
 			log.MaestroDebugf("NetworkManager: New network config found from devicedb, reconfigure nework using new config\n")
-			this.networkConfig = &ddbNetworkConfig
-			this.submitConfig(this.networkConfig)
+			this.submitConfig(&ddbNetworkConfig)
 			//Setup the intfs using new config
 			this.setupInterfaces()
 			//Set the hostname again as we reconfigured the network
@@ -1171,7 +1270,7 @@ func (this *networkManagerInstance) SetupDeviceDBConfig() error {
 	var origNetworkConfig, updatedNetworkConfig maestroSpecs.NetworkConfigPayload
 	//Provide a copy of current network config monitor to Config monitor, not the actual config we use, this would prevent config monitor
 	//directly updating the running config(this.networkConfig).
-	origNetworkConfig = *this.networkConfig
+	this.GetNetworkConfig(&origNetworkConfig)
 
 	//Adding monitor config
 	this.ddbConfigClient.AddMonitorConfig(&origNetworkConfig, &updatedNetworkConfig, DDB_NETWORK_CONFIG_NAME, configAna)
@@ -1345,7 +1444,7 @@ DhcpLoop:
 				ok, ifpref, r := this.primaryTable.findPreferredRoute()
 				if ok {
 					log.MaestroWarnf("NetworkManager:(DhcpLoop) preferred default route is on if %s - %+v\n", ifpref, r)
-					err = this.primaryTable.setPreferredRoute(!this.networkConfig.DontSetDefaultRoute)
+					err = this.primaryTable.setPreferredRoute(!this.activeNetworkConfig.DontSetDefaultRoute)
 					if err == nil {
 						log.MaestroWarnf("NetworkManager: set default route to %s %+v\n", ifpref, r)
 					} else {
@@ -1427,7 +1526,7 @@ DhcpLoop:
 					// ok, now finalize the default route
 					this.finalizePrimaryRoutes()
 					// setup DNS
-					dnsset, primarydns, err := AppendDNSResolver(ifdata.RunningIfconfig, leaseinfo, this.getNewDnsBufferForInterface(ifdata.IfName), this.networkConfig.DnsIgnoreDhcp)
+					dnsset, primarydns, err := AppendDNSResolver(ifdata.RunningIfconfig, leaseinfo, this.getNewDnsBufferForInterface(ifdata.IfName), this.activeNetworkConfig.DnsIgnoreDhcp)
 					if dnsset {
 						log.MaestroInfof("NetworkManager: adding DNS nameserver %s as primary\n", primarydns)
 						ifdata.hadDNS = true
@@ -1580,7 +1679,7 @@ DhcpLoop:
 						// }
 						//setupDefaultRouteInPrimaryTable(this,ifdata.RunningIfconfig,)
 						// setup DNS
-						dnsset, primarydns, err := AppendDNSResolver(ifdata.RunningIfconfig, leaseinfo, this.getNewDnsBufferForInterface(ifdata.IfName), this.networkConfig.DnsIgnoreDhcp)
+						dnsset, primarydns, err := AppendDNSResolver(ifdata.RunningIfconfig, leaseinfo, this.getNewDnsBufferForInterface(ifdata.IfName), this.activeNetworkConfig.DnsIgnoreDhcp)
 						if dnsset {
 							log.MaestroInfof("NetworkManager: adding DNS nameserver %s as primary\n", primarydns)
 							ifdata.hadDNS = true
@@ -1695,7 +1794,7 @@ DhcpLoop:
 					// 	}
 					// }
 					// setup DNS
-					dnsset, primarydns, err := AppendDNSResolver(ifdata.RunningIfconfig, leaseinfo, this.getNewDnsBufferForInterface(ifdata.IfName), this.networkConfig.DnsIgnoreDhcp)
+					dnsset, primarydns, err := AppendDNSResolver(ifdata.RunningIfconfig, leaseinfo, this.getNewDnsBufferForInterface(ifdata.IfName), this.activeNetworkConfig.DnsIgnoreDhcp)
 					if dnsset {
 						log.MaestroInfof("NetworkManager: adding DNS nameserver %s as primary\n", primarydns)
 						ifdata.hadDNS = true
@@ -1769,7 +1868,7 @@ func (mgr *networkManagerInstance) finalizePrimaryRoutes() {
 	log.MaestroDebugf("NetworkManager: finalizePrimaryRoutes: if %s - %+v (ok=%v)\n", ifpref, r, ok)
 	if ok {
 		log.MaestroDebugf("NetworkManager: preferred default route is on if %s - %+v\n", ifpref, r)
-		err := mgr.primaryTable.setPreferredRoute(!mgr.networkConfig.DontSetDefaultRoute)
+		err := mgr.primaryTable.setPreferredRoute(!mgr.activeNetworkConfig.DontSetDefaultRoute)
 		if err == nil {
 			log.MaestroDebugf("NetworkManager: set default route to %s %+v\n", ifpref, r)
 		} else {
@@ -2113,7 +2212,7 @@ func (mgr *networkManagerInstance) SubmitTask(task *tasks.MaestroTask) (errout e
 									errout = err2
 									return
 								}
-							}		
+							}
 						}
 
 						// takes the state of the NetIfConfigPayload
@@ -2307,19 +2406,20 @@ func (mgr *networkManagerInstance) ValidateTask(task *tasks.MaestroTask) error {
 func InitNetworkManager(networkconfig *maestroSpecs.NetworkConfigPayload, ddbconfig *maestroConfig.DeviceDBConnConfig) error {
 	log.MaestroInfof("NetworkManager: Initializing %v %v\n", networkconfig, ddbconfig)
 	inst := GetInstance()
-	inst.networkConfig = networkconfig
 	inst.ddbConnConfig = ddbconfig
 
 	//Setup the config with the given network config
-	if inst.networkConfig != nil {
-		if inst.networkConfig.Disable == false {
+	if networkconfig != nil {
+		inst.activeNetworkConfig.Disable = networkconfig.Disable
+		if inst.activeNetworkConfig.Disable == false {
 			log.MaestroInfof("NetworkManager: Submit config read from config file\n")
-			inst.submitConfig(inst.networkConfig)
+			inst.submitConfig(networkconfig)
 		} else {
 			log.MaestroWarnf("NetworkManager: Network configuration Disable flag set to true\n")
 			return nil
 		}
 	} else {
+		inst.activeNetworkConfig.Disable = true
 		return errors.New("NetworkManager: No network configuration set, unable to cofigure network")
 	}
 

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -766,56 +766,58 @@ func updateIfConfigFromStored(netdata *NetworkInterfaceData) (ok bool, err error
 // nor does it update DeviceDB
 func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkConfigPayload) {
 
-	if this.activeNetworkConfig.DontSetDefaultRoute != config.DontSetDefaultRoute {
-		this.activeNetworkConfig.DontSetDefaultRoute = config.DontSetDefaultRoute
-		log.MaestroInfof("NetworkManager: submitConfig: DontSetDefaultRoute changed to: %t\n",
-				 this.activeNetworkConfig.DontSetDefaultRoute)
-	}
+	if config.Existing == "replace" {
+		if this.activeNetworkConfig.DontSetDefaultRoute != config.DontSetDefaultRoute {
+			this.activeNetworkConfig.DontSetDefaultRoute = config.DontSetDefaultRoute
+			log.MaestroInfof("NetworkManager: submitConfig: DontSetDefaultRoute changed to: %t\n",
+					 this.activeNetworkConfig.DontSetDefaultRoute)
+		}
 
-	if this.activeNetworkConfig.DnsIgnoreDhcp != config.DnsIgnoreDhcp {
-		this.activeNetworkConfig.DnsIgnoreDhcp = config.DnsIgnoreDhcp
-		log.MaestroInfof("NetworkManager: submitConfig: DnsIgnoreDhcp changed to: %t\n",
-				 this.activeNetworkConfig.DnsIgnoreDhcp)
-	}
+		if this.activeNetworkConfig.DnsIgnoreDhcp != config.DnsIgnoreDhcp {
+			this.activeNetworkConfig.DnsIgnoreDhcp = config.DnsIgnoreDhcp
+			log.MaestroInfof("NetworkManager: submitConfig: DnsIgnoreDhcp changed to: %t\n",
+					 this.activeNetworkConfig.DnsIgnoreDhcp)
+		}
 
-	if this.activeNetworkConfig.AltResolvConf != config.AltResolvConf {
-		this.activeNetworkConfig.AltResolvConf = config.AltResolvConf
-		log.MaestroInfof("NetworkManager: submitConfig: AltResolvConf changed to: %s\n",
-				 this.activeNetworkConfig.AltResolvConf)
-	}
+		if this.activeNetworkConfig.AltResolvConf != config.AltResolvConf {
+			this.activeNetworkConfig.AltResolvConf = config.AltResolvConf
+			log.MaestroInfof("NetworkManager: submitConfig: AltResolvConf changed to: %s\n",
+					 this.activeNetworkConfig.AltResolvConf)
+		}
 
-	if this.activeNetworkConfig.DnsRunLocalCaching != config.DnsRunLocalCaching {
-		this.activeNetworkConfig.DnsRunLocalCaching = config.DnsRunLocalCaching
-		log.MaestroInfof("NetworkManager: submitConfig: DnsRunLocalCaching changed to: %t\n",
-				 this.activeNetworkConfig.DnsRunLocalCaching)
-	}
+		if this.activeNetworkConfig.DnsRunLocalCaching != config.DnsRunLocalCaching {
+			this.activeNetworkConfig.DnsRunLocalCaching = config.DnsRunLocalCaching
+			log.MaestroInfof("NetworkManager: submitConfig: DnsRunLocalCaching changed to: %t\n",
+					 this.activeNetworkConfig.DnsRunLocalCaching)
+		}
 
-	if this.activeNetworkConfig.DnsForwardTo != config.DnsForwardTo {
-		this.activeNetworkConfig.DnsForwardTo = config.DnsForwardTo
-		log.MaestroInfof("NetworkManager: submitConfig: DnsForwardTo changed to: %s\n",
-				 this.activeNetworkConfig.DnsForwardTo)
-	}
+		if this.activeNetworkConfig.DnsForwardTo != config.DnsForwardTo {
+			this.activeNetworkConfig.DnsForwardTo = config.DnsForwardTo
+			log.MaestroInfof("NetworkManager: submitConfig: DnsForwardTo changed to: %s\n",
+					 this.activeNetworkConfig.DnsForwardTo)
+		}
 
-	if this.activeNetworkConfig.DnsRunRootLookup != config.DnsRunRootLookup {
-		this.activeNetworkConfig.DnsRunRootLookup = config.DnsRunRootLookup
-		log.MaestroInfof("NetworkManager: submitConfig: DnsRunRootLookup changed to: %t\n",
-				 this.activeNetworkConfig.DnsRunRootLookup)
-	}
+		if this.activeNetworkConfig.DnsRunRootLookup != config.DnsRunRootLookup {
+			this.activeNetworkConfig.DnsRunRootLookup = config.DnsRunRootLookup
+			log.MaestroInfof("NetworkManager: submitConfig: DnsRunRootLookup changed to: %t\n",
+					 this.activeNetworkConfig.DnsRunRootLookup)
+		}
 
-	if this.activeNetworkConfig.DnsHostsData != config.DnsHostsData {
-		this.activeNetworkConfig.DnsHostsData = config.DnsHostsData
-		log.MaestroInfof("NetworkManager: submitConfig: DnsHostsData changed to: %s\n",
-				 this.activeNetworkConfig.DnsHostsData)
-	}
+		if this.activeNetworkConfig.DnsHostsData != config.DnsHostsData {
+			this.activeNetworkConfig.DnsHostsData = config.DnsHostsData
+			log.MaestroInfof("NetworkManager: submitConfig: DnsHostsData changed to: %s\n",
+					 this.activeNetworkConfig.DnsHostsData)
+		}
 
-	if this.activeNetworkConfig.FallbackNameservers != config.FallbackNameservers {
-		this.activeNetworkConfig.FallbackNameservers = config.FallbackNameservers
-		log.MaestroInfof("NetworkManager: submitConfig: FallbackNameservers changed to: %s\n",
-				 this.activeNetworkConfig.FallbackNameservers)
-	}
+		if this.activeNetworkConfig.FallbackNameservers != config.FallbackNameservers {
+			this.activeNetworkConfig.FallbackNameservers = config.FallbackNameservers
+			log.MaestroInfof("NetworkManager: submitConfig: FallbackNameservers changed to: %s\n",
+					 this.activeNetworkConfig.FallbackNameservers)
+		}
 
-	// skip Existing
-	// skip Disable.  we don't handle the case where we enable/disable after initial startup
+		// skip Existing
+		// skip Disable since we don't handle the case where we enable/disable after initial startup
+	}
 
 	// update the interfaces map and maestroDB
 	for _, ifconf := range config.Interfaces {

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -729,55 +729,8 @@ func updateIfConfigFromStored(netdata *NetworkInterfaceData) (ok bool, err error
 	return
 }
 
-func (this *networkManagerInstance) resetLinks() {
-	log.MaestroDebugf("NetworkManager: resetLinks: reset all network links\n")
-	//This function brings all the intfs down and puts everything back in pristine state
-	this.byInterfaceName.Range(func(key, value interface{}) bool {
-		if value == nil {
-			debugging.DEBUG_OUT("NetworkManager: resetLinks: Invalid Entry in syncmap - have null value pointer\n")
-			return true
-		}
-		ifname := "<interface name>"
-		ifname, _ = key.(string)
-		log.MaestroDebugf("NetworkManager: found existing key for if [%s]\n", ifname)
-		if value != nil {
-			ifdata := value.(*NetworkInterfaceData)
-			//First kill the DHCP routine if its running
-			if ifdata.dhcpRunning {
-				log.MaestroDebugf("NetworkManager: resetLinks: Stopping DHCP routine for if %s\n", ifname)
-				ifdata.dhcpWorkerControl <- networkThreadMessage{cmd: stop_and_release_IP}
-				// wait on that shutdown
-				<-ifdata.dhcpWaitOnShutdown
-				//Set the flag
-				ifdata.dhcpRunning = false
-			}
-			//ifdata := (*NetworkInterfaceData)(item.Value)
-			log.MaestroDebugf("NetworkManager: Remove the interface config/settings from syncmap for if [%s]\n", ifname)
-			//Clear/Remove the interface config/settings from syncmap
-			link, err := GetInterfaceLink(ifname, -1)
-			if err == nil && link != nil {
-				ifname = link.Attrs().Name
-				// ok - need to bring interface down to set Mac
-				log.MaestroDebugf("NetworkManager: resetLinks: bringing if %s down\n", ifname)
-				err2 := netlink.LinkSetDown(link)
-				if err2 != nil {
-					log.MaestroErrorf("NetworkManager: resetLinks: failed to bring if %s down - %s\n", ifname, err2.Error())
-				}
-				//Now we can remove the entry from syncmap
-				this.byInterfaceName.Delete(key)
-			}
-		}
-		return true
-	})
-}
-
 func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkConfigPayload) {
 	this.networkConfig = config
-
-	//reset all current config if this function is called again
-	if len(config.Interfaces) > 0 {
-		this.resetLinks()
-	}
 
 	// NOTE: this is only for the config file initial start
 	// NOTE: the database must already be loaded and read
@@ -1006,6 +959,33 @@ func (this *networkManagerInstance) SetInterfaceConfigByName(ifname string, ifco
 	return
 }
 
+func (this *networkManagerInstance) ifdown(ifname string) {
+	ifdata := this.getInterfaceData(ifname)
+	if ifdata != nil {
+		log.MaestroErrorf("NetworkManager: ifdown unknown interface: %s\n", ifname)
+		return
+	}
+
+	// kill the DHCP routine if its running
+	if ifdata.dhcpRunning {
+		log.MaestroDebugf("NetworkManager: ifdown: Stopping DHCP routine for if %s\n", ifname)
+		ifdata.dhcpWorkerControl <- networkThreadMessage{cmd: stop_and_release_IP}
+		// wait on that shutdown
+		<-ifdata.dhcpWaitOnShutdown
+		ifdata.dhcpRunning = false
+	}
+
+	log.MaestroDebugf("NetworkManager: ifdown: Setting link down for if %s \n", ifname)
+	link, err := GetInterfaceLink(ifname, -1)
+	if err == nil && link != nil {
+		ifname = link.Attrs().Name
+		err2 := netlink.LinkSetDown(link)
+		if err2 != nil {
+			log.MaestroErrorf("NetworkManager: ifdown: failed to set link down for if %s: %s\n", ifname, err2.Error())
+		}
+	}
+}
+
 func (this *networkManagerInstance) setupInterfaces() (err error) {
 
 	this.byInterfaceName.Range(func(key, value interface{}) bool {
@@ -1014,7 +994,6 @@ func (this *networkManagerInstance) setupInterfaces() (err error) {
 			return true
 		}
 		ifname := "<interface name>"
-		//ifname, _ = item.Key.(string)
 		ifname, _ = key.(string)
 		log.MaestroDebugf("NetworkManager: see existing setup for if [%s]\n", ifname)
 		if value != nil {
@@ -1023,6 +1002,8 @@ func (this *networkManagerInstance) setupInterfaces() (err error) {
 				log.MaestroErrorf("NetworkManager: Interface [%s] does not have an interface data structure.\n", ifname)
 				return true
 			}
+
+			this.ifdown(ifname)
 
 			var ifconfig *maestroSpecs.NetIfConfigPayload
 

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -1158,7 +1158,7 @@ func (this *networkManagerInstance) setupInterfaces() (err error) {
 //This function calls the setupInterfaces with the current config and then start connection with devicedb by calling initDeviceDBConfig
 //Note that call to initDeviceDBConfig is done as a go routine.
 func (this *networkManagerInstance) SetupExistingInterfaces() (err error) {
-	log.MaestroInfof("NetworkManager: Setup the intfs using initial boot config first: %v:%v\n", this.activeNetworkConfig, this.activeNetworkConfig.Interfaces)
+	log.MaestroInfof("NetworkManager: Setup the intfs using initial boot config first: %+v\n", this.activeNetworkConfig)
 
 	if this.activeNetworkConfig.Disable == true {
 		log.MaestroInfo("NetworkManager: Network management is disabled.  No interfaces to bring up.\n")
@@ -1187,7 +1187,7 @@ func (this *networkManagerInstance) initDeviceDBConfig() error {
 
 	err = this.SetupDeviceDBConfig()
 	if err != nil {
-		log.MaestroErrorf("NetworkManager: error setting up config using devicedb: %v", err)
+		log.MaestroErrorf("NetworkManager: error setting up config using devicedb: %v\n", err)
 	} else {
 		log.MaestroInfof("NetworkManager: successfully read config from devicedb\n")
 	}
@@ -1229,7 +1229,7 @@ func (this *networkManagerInstance) SetupDeviceDBConfig() error {
 	//Create a config analyzer object, required for registering the config change hook and diff the config objects.
 	configAna := maestroSpecs.NewConfigAnalyzer(DDB_NETWORK_CONFIG_CONFIG_GROUP_ID)
 	if configAna == nil {
-		log.MaestroErrorf("NetworkManager: Failed to create config analyzer object, unable to fetch config from devicedb")
+		log.MaestroErrorf("NetworkManager: Failed to create config analyzer object, unable to fetch config from devicedb\n")
 		return errors.New("Failed to create config analyzer object, unable to fetch config from devicedb")
 	}
 

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -1167,6 +1167,10 @@ func (this *networkManagerInstance) SetupExistingInterfaces() (err error) {
 		return
 	}
 
+	// don't wait for setupInterfaces() to apply DNS, which can be quite a delay
+	// if the interfaces are all dhcp
+	this.finalizeDns()
+
 	//Setup the intfs using initial boot config first
 	this.setupInterfaces()
 

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -1019,6 +1019,9 @@ func (this *networkManagerInstance) loadAllInterfaceData() (err error) {
 	var temp NetworkInterfaceData
 	this.networkConfigDB.IterateIf(func(key []byte, val interface{}) bool {
 		ifname := string(key[:])
+		if ifname == "nameservers" {
+			return true
+		}
 		ifdata, ok := val.(*NetworkInterfaceData)
 		if ok {
 			err2 := resetIfDataFromStoredConfig(ifdata)

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -270,6 +270,9 @@ func (this *networkManagerInstance) AbortFutureConfig() {
 }
 
 func (this *networkManagerInstance) ApplyFutureConfig() error {
+	if this.futureNetworkConfig == nil {
+		return nil
+	}
 	this.submitConfig(this.futureNetworkConfig)
 	this.futureNetworkConfig = nil
 	return this.setupInterfaces()
@@ -791,6 +794,11 @@ func (this *networkManagerInstance) copyInterfacesStoredToActive() {
 // runtime data structures, it does not activate any of the new config on the host system
 // nor does it update DeviceDB
 func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkConfigPayload) {
+
+	if config == nil {
+		log.MaestroErrorf("NetworkManager: attempt to apply nil config\n")
+		return
+	}
 
 	if config.Existing == "replace" {
 		if this.activeNetworkConfig.DontSetDefaultRoute != config.DontSetDefaultRoute {

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -367,16 +367,16 @@ func (inst *networkManagerInstance) finalizeDns() (err error) {
 	if len(inst.activeNetworkConfig.AltResolvConf) > 0 {
 		dnsconfig, err2 := ioutil.ReadFile(inst.activeNetworkConfig.AltResolvConf)
 		if err2 != nil {
-			log.MaestroErrorf("NetworkManager: failed to read DNS resolv.conf")
-			return
+			log.MaestroErrorf("NetworkManager: failed to read DNS resolv.conf\n")
+			return err2
 		}
 
 		cmd := exec.Command("resolvconf", "-a", "maestro.net")
 
 		stdin, errp := cmd.StdinPipe()
 		if errp != nil {
-			log.MaestroErrorf("NetworkManager: failed to create command pipe for resolvconf: %v", errp)
-			return
+			log.MaestroErrorf("NetworkManager: failed to create command pipe for resolvconf: %v\n", errp)
+			return errp
 		}
 
 		stdin.Write(dnsconfig)
@@ -384,8 +384,10 @@ func (inst *networkManagerInstance) finalizeDns() (err error) {
 
 		rc := cmd.Run()
 		if rc != nil {
-			log.MaestroDebugf("failed to call resolvconf: %v", rc)
+			log.MaestroDebugf("failed to call resolvconf: %v\n", rc)
+			return rc
 		}
+		log.MaestroDebugf("successfully called resolvconf\n")
 	}
 
 	return

--- a/networking/manager.go
+++ b/networking/manager.go
@@ -841,22 +841,19 @@ func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkCon
 	//get the stored dns servers
 	this.networkConfigDB.Get(dnsid, &storedconfig)
 
-	if config.Existing == "replace" {
+	if config.Existing == "replace" || (config.Existing == "override" && len(config.Nameservers) > 0) {
 		//erase and replace the nameservers
 		storedconfig = nil
 		storedconfig = append(storedconfig, config.Nameservers...)
 
 		//store name servers
 		this.networkConfigDB.Put(dnsid, storedconfig)
-	} else if config.Existing == "override" {
-		if len(config.Nameservers) > 0 {
-			//erase and replace the nameservers
-			storedconfig = nil
-			storedconfig = append(storedconfig, config.Nameservers...)
+	} else if config.Existing == "" && len(storedconfig) == 0 {
+		//write to nameservers if nothing exists
+		storedconfig = append(storedconfig, config.Nameservers...)
 
-			//store name servers
-			this.networkConfigDB.Put(dnsid, storedconfig)
-		}
+		//store name servers
+		this.networkConfigDB.Put(dnsid, storedconfig)
 	}
 
 	//store to active config

--- a/networking/networkConfigMonitor.go
+++ b/networking/networkConfigMonitor.go
@@ -91,9 +91,9 @@ func (cfgHook NetworkConfigChangeHook) ChangesStart(configgroup string) {
 	instance = GetInstance()
 	err := instance.StartFutureConfig()
 	if err != nil {
-		log.MaestroInfof("ConfigChangeHook:ChangesStart: failed to start networkConfig changes: %s\n", err.Error())
-		instance.AbortFutureConfig()
-		instance.StartFutureConfig()
+		log.MaestroDebugf("ConfigChangeHook:ChangesStart: failed to start new networkConfig changes: %s\n", err.Error())
+		// this is ok since the ChangesStart function is called once per configgroup, and the
+		// NetworkConfigPayload contains multiple configgroups
 	}
 	if configChangeRequestChan == nil {
 		configChangeRequestChan = make(chan ConfigChangeInfo, 100)


### PR DESCRIPTION
Commit:
Bug fix: Allow setting the nameserver without existing flag

On first startup or boot of maestro, allow the nameserver to be sent
to maestro DB and deviceDB regardless of the existing flag.

Still allow existing flag to dictate future commits of the nameserver during
runtime