### PR TITLE
fix bug: nameservers shouldn't be added to the interfaces array

### DIFF
--- a/networking/manager.go
+++ b/networking/manager.go
@@ -1019,6 +1019,9 @@ func (this *networkManagerInstance) loadAllInterfaceData() (err error) {
 	var temp NetworkInterfaceData
 	this.networkConfigDB.IterateIf(func(key []byte, val interface{}) bool {
 		ifname := string(key[:])
+		if ifname == "nameservers" {
+			return true
+		}
 		ifdata, ok := val.(*NetworkInterfaceData)
 		if ok {
 			err2 := resetIfDataFromStoredConfig(ifdata)


### PR DESCRIPTION
'nameservers' is a key within the networkConfig DB but it should
not be considered as an interface.