### PR TITLE
don't segfault on an empty config

### DIFF
--- a/networking/manager.go
+++ b/networking/manager.go
@@ -270,6 +270,9 @@ func (this *networkManagerInstance) AbortFutureConfig() {
 }
 
 func (this *networkManagerInstance) ApplyFutureConfig() error {
+	if this.futureNetworkConfig == nil {
+		return nil
+	}
 	this.submitConfig(this.futureNetworkConfig)
 	this.futureNetworkConfig = nil
 	return this.setupInterfaces()
@@ -791,6 +794,11 @@ func (this *networkManagerInstance) copyInterfacesStoredToActive() {
 // runtime data structures, it does not activate any of the new config on the host system
 // nor does it update DeviceDB
 func (this *networkManagerInstance) submitConfig(config *maestroSpecs.NetworkConfigPayload) {
+
+	if config == nil {
+		log.MaestroErrorf("NetworkManager: attempt to apply nil config\n")
+		return
+	}
 
 	if config.Existing == "replace" {
 		if this.activeNetworkConfig.DontSetDefaultRoute != config.DontSetDefaultRoute {


### PR DESCRIPTION
handle the case where the user sends a NETWORK_COMMIT_FLAG without
first sending a NETWORK_COMMIT.